### PR TITLE
Flexible redirect URL for sign in with Auth0|Google

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,11 +27,11 @@ class SessionsController < ApplicationController
         save_session_key @member.id, cookies['_peatio_session']
         save_signup_history @member.id
         MemberMailer.notify_signin(@member.id).deliver if @member.activated?
-        redirect_back_or_settings_page
+        redirect_on_successful_sign_in
       end
     else
       increase_failed_logins
-      redirect_to signin_path, alert: t('.error')
+      redirect_on_unsuccessful_sign_in
     end
   end
 
@@ -46,7 +46,7 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
-  private
+private
 
   def require_captcha?
     failed_logins > 3
@@ -81,4 +81,17 @@ class SessionsController < ApplicationController
     )
   end
 
+  def redirect_on_successful_sign_in
+    "#{params[:provider].to_s.upcase}_OAUTH2_REDIRECT_URL".tap do |key|
+      if ENV[key]
+        redirect_to ENV[key]
+      else
+        redirect_back_or_settings_page
+      end
+    end
+  end
+
+  def redirect_on_unsuccessful_sign_in
+    redirect_to signin_path, alert: t('.error')
+  end
 end

--- a/lib/generators/config/templates/application.yml.erb
+++ b/lib/generators/config/templates/application.yml.erb
@@ -84,9 +84,10 @@ defaults: &defaults
 
   # Configuration variables for sign in with Google.
   # See https://github.com/zquestz/omniauth-google-oauth2
-  GOOGLE_OAUTH2_SIGN_IN: ~ # Set to "on" to enable.
+  GOOGLE_OAUTH2_SIGN_IN:      ~ # Set to "on" to enable.
   GOOGLE_CLIENT_ID:
   GOOGLE_CLIENT_SECRET:
+  GOOGLE_OAUTH2_REDIRECT_URL: ~ # Specify URL address to which user will be redirected after successful sign in.
 
   # Configuration variables for sign in with Auth0.
   # See https://github.com/auth0/omniauth-auth0
@@ -94,6 +95,7 @@ defaults: &defaults
   AUTH0_OAUTH2_DOMAIN:
   AUTH0_OAUTH2_CLIENT_ID:
   AUTH0_OAUTH2_CLIENT_SECRET:
+  AUTH0_OAUTH2_REDIRECT_URL:  ~ # Specify URL address to which user will be redirected after successful sign in.
 
 development:
   <<: *defaults

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -21,9 +21,23 @@ describe SessionsController, type: :controller do
         expect(session[:member_id]).to_not be_nil
       end
 
-      it 'should redirect the member to the settings url' do
-        post :create, provider: provider
-        expect(response).to redirect_to settings_url
+      context 'when no redirect URL is specified' do
+        before { ENV.delete("#{provider.upcase}_OAUTH2_REDIRECT_URL") }
+
+        it 'should redirect the member to the settings URL' do
+          post :create, provider: provider
+          expect(response).to redirect_to settings_url
+        end
+      end
+
+      context 'when redirect URL is specified in environment' do
+        let(:redirect_url) { 'https://foo.bar' }
+        before { ENV["#{provider.upcase}_OAUTH2_REDIRECT_URL"] = redirect_url }
+
+        it 'should redirect the member to the specified URL' do
+          post :create, provider: provider
+          expect(response).to redirect_to redirect_url
+        end
       end
 
       it 'should successfully destroy a session' do


### PR DESCRIPTION
Allow to specify URL address to which user will be redirected after successful sign in with Auth0|Google.