### PR TITLE
Fix syntax error during pre-compile assets

### DIFF
--- a/app/api/api_v2/constraints.rb
+++ b/app/api/api_v2/constraints.rb
@@ -12,7 +12,7 @@ module APIv2
         end
 
         Rack::Attack.throttle 'Authorized access', limit: 6000, period: 5.minutes do |req|
-          req.env['api_v2.keypair_token']&.access_key
+          req.env['api_v2.keypair_token'].access_key
         end
       end
     end


### PR DESCRIPTION
Fixed error during pre-compile assets:

SyntaxError: /home/deploy/peatio/current/app/api/api_v2/constraints.rb:15: syntax error, unexpected '.'
          req.env['api_v2.keypair_token']&.access_key