### PR TITLE
Clear user session stored in Redis via API call DELETE /api/v2/sessions (closes #697)

### DIFF
--- a/app/api/api_v2/helpers.rb
+++ b/app/api/api_v2/helpers.rb
@@ -111,6 +111,5 @@ module APIv2
         JSON.parse('[%s]' % redis.lrange(key, offset, -1).join(','))
       end
     end
-
   end
 end

--- a/app/api/api_v2/mount.rb
+++ b/app/api/api_v2/mount.rb
@@ -35,6 +35,7 @@ module APIv2
     mount APIv2::K
     mount APIv2::Tools
     mount APIv2::Withdraws
+    mount APIv2::Sessions
 
     base_path = Rails.env.production? ? "#{ENV['URL_SCHEME']}://#{ENV['URL_HOST']}/#{PREFIX}" : PREFIX
     add_swagger_documentation base_path: base_path,

--- a/app/api/api_v2/sessions.rb
+++ b/app/api/api_v2/sessions.rb
@@ -1,0 +1,13 @@
+module APIv2
+  class Sessions < Grape::API
+    helpers { include SessionUtils }
+
+    before { authenticate! }
+
+    desc 'Delete all user sessions.'
+    delete '/sessions' do
+      destroy_member_sessions(current_user.id)
+      status 200
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include SessionUtils
   protect_from_forgery with: :exception
 
   helper_method :current_user, :is_admin?, :current_market, :gon
@@ -163,18 +164,6 @@ class ApplicationController < ActionController::Base
 
   def coin_rpc_connection_refused
     render 'errors/connection'
-  end
-
-  def save_session_key(member_id, key)
-    Rails.cache.write "peatio:sessions:#{member_id}:#{key}", 1, expire_after: ENV['SESSION_EXPIRE'].to_i.minutes
-  end
-
-  def clear_all_sessions(member_id)
-    if redis = Rails.cache.instance_variable_get(:@data)
-      redis.keys("peatio:sessions:#{member_id}:*").each {|k| Rails.cache.delete k.split(':').last }
-    end
-
-    Rails.cache.delete_matched "peatio:sessions:#{member_id}:*"
   end
 
   def allow_iframe

--- a/app/controllers/concerns/session_utils.rb
+++ b/app/controllers/concerns/session_utils.rb
@@ -1,0 +1,13 @@
+module SessionUtils
+  def memoize_member_session_id(member_id, session_id)
+    Rails.cache.write("peatio:sessions:#{member_id}:#{session_id}", 1, expire_after: ENV.fetch('SESSION_EXPIRE').to_i.minutes)
+  end
+
+  def destroy_member_sessions(member_id)
+    redis = Rails.cache.instance_variable_get(:@data)
+    redis.keys("peatio:sessions:#{member_id}:*")
+         .map { |k| [k, k.split(':').last] }
+         .flatten
+         .tap { |keys| redis.del(*keys) }
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
 
     reset_session rescue nil
     session[:member_id] = @member.id
-    save_session_key @member.id, cookies['_peatio_session']
+    memoize_member_session_id @member.id, session.id
     redirect_on_successful_sign_in
   end
 
@@ -19,7 +19,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    clear_all_sessions current_user.id
+    destroy_member_sessions(current_user.id)
     reset_session
     redirect_to root_path
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,9 +15,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Use a different cache store in development.
-  config.cache_store = :redis_store, ENV['REDIS_URL']
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,9 +49,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ENV['FORCE_SECURE_CONNECTION'] == 'true'
 
-  # Use a different cache store in production.
-  config.cache_store = :redis_store, ENV['REDIS_URL']
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/environments/shared/cache.rb
+++ b/config/environments/shared/cache.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.cache_store = :redis_store, ENV.fetch('REDIS_URL')
+end

--- a/spec/api/api_v2/sessions_spec.rb
+++ b/spec/api/api_v2/sessions_spec.rb
@@ -1,0 +1,59 @@
+describe APIv2::Sessions, type: :request do
+  let(:member) { create(:member, :verified_identity) }
+  let(:token) { jwt_for(member) }
+  let(:session_utils) { Class.new { include SessionUtils }.new }
+
+  describe 'DELETE /sessions' do
+    context 'without token'
+      it 'should require authentication' do
+        api_delete '/api/v2/sessions'
+        expect(response.code).to eq '401'
+      end
+
+    context 'with valid token' do
+      it 'should delete all session from redis storage' do
+        def sid; response.cookies.fetch('_peatio_session'); end
+
+        session_ids = []
+        redis       = Rails.cache.instance_variable_get(:@data)
+
+        # Step 1: Establish user session (but not authenticated).
+        get '/funds'
+        session_utils.memoize_member_session_id(member.id, sid) # This saves user SID in Redis. Check SessionsController#create for the details.
+        expect(response.status).to eq 302 # Redirects to index with flash: "Please, sign in to see this page".
+
+        # Mock member ID directly in session store.
+        session = redis.get(sid)
+        session_utils.memoize_member_session_id(member.id, sid)
+        session_ids << sid
+        session['member_id'] = member.id
+        redis.set(sid, session)
+
+        # Check that worked.
+        get '/funds'
+        expect(response.status).to eq 200 # OK. We are really signed in.
+        session_utils.memoize_member_session_id(member.id, sid)
+        session_ids << sid
+
+        # Again, ensure data really exists at Redis.
+        expect(session_ids.map { |sid| redis.get(sid) }.count).to eq session_ids.count
+        expect(redis.keys("peatio:sessions:#{member.id}:*")).to_not be_empty
+
+        # Finally, ask API to destroy session.
+        api_delete '/api/v2/sessions', token: token
+        expect(response.code).to eq '200'
+
+        # Ensure all session stuff is destroyed.
+        expect(session_ids.map { |sid| redis.get(sid) }.compact).to be_empty
+        expect(redis.keys("peatio:sessions:#{member.id}:*")).to be_empty
+      end
+    end
+
+    context 'without session established' do
+      it 'should not fail' do
+        api_delete '/api/v2/sessions', token: token
+        expect(response.code).to eq '200'
+      end
+    end
+  end
+end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -16,6 +16,10 @@ module APITestHelpers
     api_request(:post, *args)
   end
 
+  def api_delete(*args)
+    api_request(:delete, *args)
+  end
+
   #
   # Generates valid JWT for member, allows to pass additional payload.
   #


### PR DESCRIPTION
```NoMethodError (undefined method 'headers' for [204, {}, [false]]:Array):
  app/api/api_v2/cors/middleware.rb:11:in 'call'
  lib/middleware/security.rb:11:in `call'
  lib/middleware/i18n_js.rb:9:in `call'
```
I have this type of issue