### PR TITLE
Hide «unsecure protocol» warning from Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'rails', '~> 4.2'
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/oauth-xx/oauth2.git
-  revision: 49ab9a3c0d021e8d954396f33d102079588279d6
+  remote: https://github.com/oauth-xx/oauth2
+  revision: a934b65872f2141aca56bf1f8bba0960ff50e248
   specs:
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.15.0)


### PR DESCRIPTION
Fixes the following warning while running `bundle install`

> The git source `git://github.com/oauth-xx/oauth2.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
