### PR TITLE
add better-errors gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ end
 
 group :development do
   gem 'annotate', '~> 2.7'
+  gem 'better_errors'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,10 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    better_errors (2.4.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.2)
@@ -135,6 +139,7 @@ GEM
     enumerize (2.1.2)
       activesupport (>= 3.2)
     equalizer (0.0.11)
+    erubi (1.7.1)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
@@ -424,6 +429,7 @@ DEPENDENCIES
   angularjs-rails (~> 1.3.15)
   annotate (~> 2.7)
   arel-is-blank (~> 1.0)
+  better_errors
   binding_of_caller
   bootstrap-sass (~> 3.2.0.2)
   bourbon


### PR DESCRIPTION
Better Errors replaces the standard Rails error page with a much better and more useful error page.
https://github.com/charliesome/better_errors