### PR TITLE
Brakeman gem added to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'pusher'
 gem 'eventmachine', '~> 1.0.4'
 gem 'em-websocket', '~> 0.5.1'
 
+gem 'rails-html-sanitizer', '~> 1.0.4'
 gem 'simple_form', '~> 3.1.0'
 gem 'slim-rails'
 gem 'sass-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ end
 
 group :development do
   gem 'annotate', '~> 2.7'
+  gem 'brakeman', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,8 +296,8 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rails-i18n (4.0.9)
       i18n (~> 0.7)
       railties (~> 4.0)
@@ -485,6 +485,7 @@ DEPENDENCIES
   rack-attack (~> 4.3.1)
   rack_session_access (~> 0.1)
   rails (~> 4.2)
+  rails-html-sanitizer (~> 1.0.4)
   rails-i18n
   rails-observers
   rbtree

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
+    brakeman (4.2.1)
     browser (0.8.0)
     builder (3.2.3)
     bunny (2.9.0)
@@ -427,6 +428,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass (~> 3.2.0.2)
   bourbon
+  brakeman
   browser (~> 0.8.0)
   bunny (~> 2.9.0)
   cancancan

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -154,7 +154,7 @@ class Account < ActiveRecord::Base
   def change_balance_and_locked(delta_b, delta_l)
     self.balance += delta_b
     self.locked  += delta_l
-    self.class.connection.execute "update accounts set balance = balance + #{delta_b}, locked = locked + #{delta_l} where id = #{id}"
+    self.class.connection.execute("UPDATE accounts SET balance = balance + ?, locked = locked + ? where id = ?", delta_b, delta_b, id)
     add_to_transaction # so after_commit will be triggered
     self
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "83db155235cf802b8d57568473fd206603029c7bfbf80263a137dae38eaa6730",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method constantize called with model attribute",
+      "file": "app/controllers/private/withdraw_destinations_controller.rb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "\"withdraw_destination/#{Currency.find_by_code(params[:currency]).type}\".camelize.constantize",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Private::WithdrawDestinationsController",
+        "method": "create"
+      },
+      "user_input": "Currency.find_by_code(params[:currency]).type",
+      "confidence": "Medium",
+      "note": "The currency type is validated properly"
+    }
+  ],
+  "updated": "2018-03-30 01:06:46 +0300",
+  "brakeman_version": "4.2.1"
+}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -19,8 +19,28 @@
       "user_input": "Currency.find_by_code(params[:currency]).type",
       "confidence": "Medium",
       "note": "The currency type is validated properly"
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "c916e8ab2cdb5b612c018bfbf8f7587115a8087965f4bd01ad7954de195d6eb5",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method constantize called with model attribute",
+      "file": "lib/coin_api.rb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "(if Currency.find_by!(:code => code.to_s).api_client.present? then\n  \"CoinAPI::#{Currency.find_by!(:code => code.to_s).api_client.camelize}\"\nelse\n  \"CoinAPI::#{code.upcase}\"\nend).constantize",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CoinAPI",
+        "method": "[]"
+      },
+      "user_input": "Currency.find_by!(:code => code.to_s).api_client",
+      "confidence": "Medium",
+      "note": "The currency type is validated properly"
     }
   ],
-  "updated": "2018-03-30 01:06:46 +0300",
+  "updated": "2018-03-30 10:53:40 +0300",
   "brakeman_version": "4.2.1"
 }


### PR DESCRIPTION
Fixes:

1. Fix CVE-2018-3741 **rails-html-sanitizer**
1. Ignore false positive warnings. Ignored rules are stored in: _config/brakeman.ignore_

Usage: `brakeman -o brakeman-report` where `brakeman-report` is a report file name