### PR TITLE
Fix error in OrderBook entity caused by class loading order bug in Grape

### DIFF
--- a/app/api/api_v2/entities/order_book.rb
+++ b/app/api/api_v2/entities/order_book.rb
@@ -1,4 +1,4 @@
-require 'api_v2/entities/order'
+require_dependency 'api_v2/entities/order'
 
 module APIv2
   module Entities

--- a/app/api/api_v2/entities/order_book.rb
+++ b/app/api/api_v2/entities/order_book.rb
@@ -1,3 +1,5 @@
+require 'api_v2/entities/order'
+
 module APIv2
   module Entities
     class OrderBook < Base


### PR DESCRIPTION
When trying to access the API endpoint for order books `http://peatio:8000/api/v2/order_book?market=usdbtc` I get the following error:

```
undefined method `represent' for #<Class:0x00007fc2cd8c8330>
```

Tracked it down to this Github issue: https://github.com/ruby-grape/grape-entity/issues/80

Fixing the class loading order by requiring the Order entity seems to fix the bug.