### PR TITLE
Fix disappearing security_configuration when module reloads

### DIFF
--- a/app/api/management_api_v1/jwt_authentication_middleware.rb
+++ b/app/api/management_api_v1/jwt_authentication_middleware.rb
@@ -3,7 +3,6 @@ require 'stringio'
 module ManagementAPIv1
   class JWTAuthenticationMiddleware < Grape::Middleware::Base
     extend Memoist
-    mattr_accessor :security_configuration
 
     def before
       return if request.path == '/management_api/v1/swagger'
@@ -56,6 +55,7 @@ module ManagementAPIv1
     end
 
     def check_jwt!(jwt)
+      security_configuration = Rails.configuration.x.security_configuration
       begin
         scope    = security_configuration.fetch(:scopes).fetch(security_scope)
         keychain = security_configuration

--- a/config/initializers/jwt.rb
+++ b/config/initializers/jwt.rb
@@ -28,5 +28,5 @@ require 'openssl'
     end
   end
 
-  ManagementAPIv1::JWTAuthenticationMiddleware.security_configuration = x
+  Rails.configuration.x.security_configuration = x
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -96,7 +96,7 @@ module APITestHelpers
   memoize :management_api_v1_algorithms
 
   def management_api_v1_security_configuration
-    ManagementAPIv1::JWTAuthenticationMiddleware.security_configuration
+    Rails.configuration.x.security_configuration
   end
 
   def defaults_for_management_api_v1_security_configuration!
@@ -105,7 +105,7 @@ module APITestHelpers
       memo[signer] = { algorithm: management_api_v1_algorithms.fetch(signer), value: key.public_key }
     end
 
-    ManagementAPIv1::JWTAuthenticationMiddleware.security_configuration = config
+    Rails.configuration.x.security_configuration = config
   end
 end
 


### PR DESCRIPTION
I experienced this issue when running the app in development mode:

https://github.com/rubykube/peatio/issues/1010

It seems to be fixed by referencing the config via `Rails.configuration.x` rather than using the `mattr_accessor`, which gets wiped every time the code for that module reloads in development.

Here's a stackoverflow issue that led me to that conclusion:

https://stackoverflow.com/questions/2419391/stop-rails-from-unloading-a-module-in-development-mode

@yivo 

This probably needs more changes as I'm assuming it breaks some tests. There may be a better solution that doesn't involve `mattr_accessor`