### PR TITLE
Add a migration to have markets.yml migrated to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## [Peatio.tech](https://www.peatio.tech) Introduction
 
 Peatio is a free and open-source crypto currency exchange implementation with the Rails framework.
-Peatio.tech is a fork of Peatio designed for micro-services architecture, we have simplified the code
+Peatio.tech is a fork of Peatio designed for micro-services architecture. We have simplified the code
 in order to use only Peatio API with external frontend and server components.
 
 To build your own exchange you should now run Peatio as a backend instead of forking the repository,
@@ -14,9 +14,9 @@ and extend it using other microservices such as [Barong](https://www.github.com/
 
 ## Mission
 
-Our mission is to build an open-source crypto currency exchange with a high performance trading engine and safety which can be trusted and enjoyed by users. We moving toward dev/ops best practices of running an enterprise grade exchange.
+Our mission is to build an open-source crypto currency exchange with a high performance trading engine and incomperable security. We are moving toward dev/ops best practices of running an enterprise grade exchange.
 
-We provide webminar or on site training for installing, configuring and administation best practices of Peatio.
+We provide webinar or on site training for installing, configuring and administation best practices of Peatio.
 Feel free to contact us for joining the next training session: [Peatio.tech](https://www.peatio.tech)
 
 Help is greatly appreciated, feel free to submit pull-requests or open issues.
@@ -48,15 +48,15 @@ Production setup:
 
 ## Things You Should Know
 
-**RUNNING A EXCHANGE IS HARD.**
+**RUNNING AN EXCHANGE IS HARD.**
 
-This repository is not a turn key solution and would require engineering and design of security process by your company, with or without our assistance. This repository is one component among many we recommand using for composing an enterprise grade exchange. It's is highly recommanded to deploy a UAT environment and build automated test for your needs, Functional tests, Smoke tests, Security vulnerability scans. You may not need to have active developer on peatio source code and we recommand the following team setup: 1 dev/ops, 3 frontend developers (react / angular), 2 QA engineers, 1 Security Officer.
+This repository is not a turn key solution and will require engineering and design of security process by your company, with or without our assistance. This repository is one component among many we recommand using for composing an enterprise grade exchange. It's is highly recommended to deploy a UAT environment and build automated test for your needs, Functional tests, Smoke tests, Security vulnerability scans. You may not need to have an active developer on peatio source code, however, we recommand the following team setup: 1 dev/ops, 3 frontend developers (react / angular), 2 QA engineers, 1 Security Officer.
 
 **SECURITY KNOWLEDGE IS A REQUIREMENT.**
 
-Peatio cannot protect your customers when you leave your admin password 1234567, or open sensitive ports to public internet. No one can. Running an exchange is a very risky task because you're dealing with money directly. If you don't known how to make your exchange secure, hire an expert.
+Peatio cannot protect your customers if you leave your admin password 1234567, or open sensitive ports to public internet. No one can. Running an exchange is a very risky task because you're dealing with money directly. If you don't know how to make your exchange secure, hire an expert.
 
-You must know what you're doing, there's no shortcut. Please get prepared before continue:
+You must know what you're doing, there's no shortcut. Please get prepared before you continue:
 
 * Rails knowledge
 * Security knowledge
@@ -86,7 +86,7 @@ You can interact with Peatio through API:
 * [API v2 docs](https://demo.peatio.tech/documents/api_v2?lang=en)
 * [Websocket API docs](https://demo.peatio.tech/documents/websocket_api)
 
-Here're some API clients/wrappers:
+Here are some API clients/wrappers:
 
 * [peatio-client-ruby](https://github.com/peatio/peatio-client-ruby) is the official ruby client of both HTTP/Websocket API.
 * [peatio-client-python by JohnnyZhao](https://github.com/JohnnyZhao/peatio-client-python) is a python client written by JohnnyZhao.
@@ -96,7 +96,7 @@ Here're some API clients/wrappers:
 
 ## Custom Styles
 
-Peatio front-end based Bootstrap 3.0 version and Sass, and you can custom exchange style for your mind.
+Peatio front-end is based Bootstrap 3.0 and Sass, so you can customize the style of your exchange.
 
 * change bootstrap default variables in `vars/_bootstrap.css.scss`
 * change peatio custom default variables in `vars/_basic.css.scss`

--- a/db/migrate/20180325001829_migrate_markets.rb
+++ b/db/migrate/20180325001829_migrate_markets.rb
@@ -1,0 +1,65 @@
+class MigrateMarkets < ActiveRecord::Migration
+
+  # Migrate markets.yml to database 'markets' table
+  #
+  # - remove code from all markets
+  # - rename base_unit to ask_unit
+  # - rename quote_unit to bid_unit
+  # - rename sort_order to position
+  # - move ask.fee to ask_fee.
+  # - move bid.fee to bid_fee
+  # - remove ask.currency
+  # - remove bid.currency
+  # - move ask.fixed to ask_precision
+  # - move bid.fixed to bid_precision
+  #
+  # eg, from markets.yml with ..
+  #
+  # - id: btcusd
+  #   code: 101
+  #   base_unit: btc
+  #   quote_unit: usd
+  #   sort_order: 1
+  #   bid: { fee: 0.0015, currency: usd, fixed: 2 }
+  #   ask: { fee: 0.0015, currency: btc, fixed: 4 }
+  #
+  # .. to 'markets' table record with ..
+  #
+  #   id: btcusd
+  #   ask_unit: btc
+  #   bid_unit: usd
+  #   position: 1
+  #   bid_fee: 0.0015
+  #   bid_precision: 2
+  #   ask_fee: 0.0015
+  #   ask_precision: 4
+
+  class Market20180325001829 < ActiveRecord::Base
+    self.table_name = 'markets'
+  end
+
+  def up
+    yml_file_location = Rails.root.join('config/markets.yml')
+    if File.file?(yml_file_location)
+      YAML.load_file(yml_file_location).each do |yml_market|
+        next if Market20180325001829.exists?(id: yml_market.fetch('id'))
+        attrs = {
+          id:             yml_market['id'],
+          ask_unit:       yml_market['base_unit'],
+          bid_unit:       yml_market['quote_unit'],
+          position:       yml_market['sort_order'],
+          ask_fee:        yml_market['ask']['fee'],
+          ask_precision:  yml_market['ask']['fixed'],
+          bid_fee:        yml_market['bid']['fee'],
+          bid_precision:  yml_market['bid']['fixed']
+        }
+        Market20180325001829.create!(attrs)
+      end
+    end
+  end
+
+  def down
+    # do nothing
+  end
+
+end

--- a/docs/setup-ubuntu.md
+++ b/docs/setup-ubuntu.md
@@ -2,7 +2,7 @@
 
 ## Docker & peatio-workbench
 
-#### We advice you to use power of [docker](https://www.docker.com) and [peatio-workbench](https://github.com/rubykube/peatio-workbench) as local development environment
+#### We advise you to use power of [docker](https://www.docker.com) and [peatio-workbench](https://github.com/rubykube/peatio-workbench) as local development environment
 
 #### Follow [this](setup-with-docker.md) guide for container-based development environmetnt setup
 

--- a/lib/peatio/version.rb
+++ b/lib/peatio/version.rb
@@ -1,3 +1,3 @@
 module Peatio
-  VERSION = '1.6.0'
+  VERSION = '1.7.0.alpha'
 end

--- a/lib/tasks/markets.rake
+++ b/lib/tasks/markets.rake
@@ -2,9 +2,12 @@ namespace :markets do
   desc 'Adds missing markets to database defined at config/seed/markets.yml.'
   task seed: :environment do
     Market.transaction do
-      YAML.load_file(Rails.root.join('config/seed/markets.yml')).each do |hash|
-        next if Market.exists?(id: hash.fetch('id'))
-        Market.create!(hash)
+      seed_yml = Rails.root.join('config/seed/markets.yml')
+      if File.file?(seed_yml)
+        YAML.load_file(seed_yml).each do |hash|
+          next if Market.exists?(id: hash.fetch('id'))
+          Market.create!(hash)
+        end
       end
     end
   end

--- a/spec/migrations/migrate_markets_spec.rb
+++ b/spec/migrations/migrate_markets_spec.rb
@@ -1,0 +1,99 @@
+load 'db/migrate/20180325001829_migrate_markets.rb'
+
+describe MigrateMarkets do
+
+  describe '#up' do
+
+    subject { described_class.new.up }
+
+    it 'should check yml file exists' do
+      File.expects(:file?).with(Rails.root.join('config/markets.yml'))
+      subject
+    end
+
+    context 'config/markets.yml does not exist' do
+
+      before { File.stubs(:file?).returns(false) }
+
+      it 'should not load yml' do
+        YAML.expects(:load_file).never
+        subject
+      end
+
+      it 'should not check for existing markets' do
+        MigrateMarkets::Market20180325001829.expects(:exists?).never
+        subject
+      end
+
+      it 'should not create any markets' do
+        MigrateMarkets::Market20180325001829.expects(:create!).never
+        subject
+      end
+
+    end
+
+    context 'config/markets.yml exists' do
+
+      before { File.stubs(:file?).returns(true) }
+
+      it 'should load yml' do
+        YAML.expects(:load_file).returns([])
+        subject
+      end
+
+      context 'with yml data' do
+
+        let(:yml_market) do
+          {
+            'id' => 'btcusd',
+            'code' => '101',
+            'base_unit' => 'btc',
+            'quote_unit' => 'usd',
+            'sort_order' => '1',
+            'bid' => {
+              'fee' => '0.0015', 'currency' => 'usd', 'fixed' => '2'
+            },
+            'ask' => {
+              'fee' => '0.0015', 'currency' => 'btc', 'fixed' => '4'
+            }
+          }
+        end
+        let(:yml_markets) { [yml_market] }
+
+        before { YAML.stubs(:load_file).returns(yml_markets) }
+
+        it 'should skip if market exists' do
+          MigrateMarkets::Market20180325001829.expects(:exists?).with(id: 'btcusd').returns('anything not nil')
+          MigrateMarkets::Market20180325001829.expects(:create!).never
+          subject
+        end
+
+        context 'not already existing in database' do
+
+          before { MigrateMarkets::Market20180325001829.stubs(:exists?).returns(nil) }
+
+          it 'should create market' do
+            MigrateMarkets::Market20180325001829.expects(:create!).with(
+              {
+                id: 'btcusd',
+                ask_unit: 'btc',
+                bid_unit: 'usd',
+                position: '1',
+                bid_fee: '0.0015',
+                bid_precision: '2',
+                ask_fee: '0.0015',
+                ask_precision: '4'
+              }
+            )
+            subject
+          end
+
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Add a migration to have config/markets.yml migrated to the database markets table rather than having to copy/edit yml then run seed task .. but leave the seed task just to ensure it doesn't fail if the seed yml does not exist.
The migration will simply do nothing if there is no config/markets.yml file available to migrate and it will not overwrite any existing markets in the database either (matching via market id)