### PR TITLE
Remove check on SENTRY_ENV

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module Peatio
   class Application < Rails::Application
 
     # Configure Sentry as early as possible.
-    if ENV['SENTRY_DSN_BACKEND'].present? && ENV['SENTRY_ENV'].to_s.split(',').include?(Rails.env)
+    if ENV['SENTRY_DSN_BACKEND'].present?
       require 'sentry-raven'
       Raven.configure { |config| config.dsn = ENV['SENTRY_DSN_BACKEND'] }
     end

--- a/config/templates/application.yml.erb
+++ b/config/templates/application.yml.erb
@@ -76,7 +76,6 @@ defaults: &defaults
   API_CORS_ALLOW_CREDENTIALS: ~
 
   # Configuration variables for Sentry.
-  SENTRY_ENV:          production # Specify environments separated by comma for which Sentry should be initialized.
   SENTRY_DSN_BACKEND:  ~          # Specify Sentry DSN used for Rails application.
   SENTRY_DSN_FRONTEND: ~          # Specify Sentry DSN used for JavaScript application.
 


### PR DESCRIPTION
Removes the check that the `SENTRY_ENV` matches or contains the `RAILS_ENV` when deciding whether to initialize and configure Raven. 

~~With this in place it isn't possible to configure Sentry to report errors from a staging infrastructure environment that is running in `Rails.env == 'production'`.~~

UPDATE: turns out that the Sentry environment variable is `SENTRY_ENVIRONMENT` so the original issue this PR was trying to solve isn't actually an issue.

The presence or absence of `SENTRY_DSN_BACKEND` is sufficient to decide whether to initialize Raven or not.