### PR TITLE
Add PUSHER_CLUSTER

### DIFF
--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -1,9 +1,10 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
-Pusher.app_id = ENV.fetch('PUSHER_APP')
-Pusher.key    = ENV.fetch('PUSHER_CLIENT_KEY')
-Pusher.secret = ENV.fetch('PUSHER_SECRET')
-Pusher.host   = ENV.fetch('PUSHER_HOST')
-Pusher.scheme = ENV.fetch('PUSHER_SCHEME')
-Pusher.port   = ENV.fetch('PUSHER_PORT')
+Pusher.app_id  = ENV.fetch('PUSHER_APP')
+Pusher.key     = ENV.fetch('PUSHER_CLIENT_KEY')
+Pusher.secret  = ENV.fetch('PUSHER_SECRET')
+Pusher.host    = ENV.fetch('PUSHER_HOST')
+Pusher.scheme  = ENV.fetch('PUSHER_SCHEME')
+Pusher.port    = ENV.fetch('PUSHER_PORT')
+Pusher.cluster = ENV.fetch('PUSHER_CLUSTER')

--- a/config/templates/application.yml.erb
+++ b/config/templates/application.yml.erb
@@ -39,6 +39,7 @@ defaults: &defaults
   PUSHER_CLIENT_WS_PORT:   '80'
   PUSHER_CLIENT_WSS_PORT:  '443'
   PUSHER_CLIENT_ENCRYPTED: 'on'
+  PUSHER_CLUSTER:          'eu'
 
   # Enabled OAuth2 provider.
   # Don't forget to check out configuration at config/initializers/omniauth.rb.


### PR DESCRIPTION
Add support for configuring pusher with `Pusher.cluster` via the PUSHER_CLUSTER environment variable. This is required by pusher.

~Default value has not been set in the `application.yml.erb` template as I'm not sure which cluster would make sense. Will update if required.~

UPDATE: I've added `eu` default as the container wouldn't build without a default value. 
UPDATE: It seems the `eu` is configured on the host in the default settings here. The config instructions in pusher no longer include host and references I can find to it set it at `api.pusherapp.com`. Possibly the cluster set within the host is being deprecated? 