### PR TITLE
Make parameter «price» in API v2 order creation to be not mandatory (fixes #1213)

### DIFF
--- a/app/api/api_v2/named_params.rb
+++ b/app/api/api_v2/named_params.rb
@@ -9,7 +9,7 @@ module APIv2
     params :order do
       requires :side,     type: String, values: %w(sell buy), desc: -> { APIv2::Entities::Order.documentation[:side] }
       requires :volume,   type: String, desc: -> { APIv2::Entities::Order.documentation[:volume] }
-      requires :price,    type: String, desc: -> { APIv2::Entities::Order.documentation[:price] }
+      optional :price,    type: String, desc: -> { APIv2::Entities::Order.documentation[:price] }
       optional :ord_type, type: String, values: -> { Order::ORD_TYPES }, default: 'limit', desc: -> { APIv2::Entities::Order.documentation[:type] }
     end
 


### PR DESCRIPTION
Parameter «price» in API v2 in order creation API should not be mandatory v1.5  #1213