### PR TITLE
Fix management API withdraw cancelation bug in 1.7 (closes #1232)

### DIFF
--- a/app/api/management_api_v1/withdraws.rb
+++ b/app/api/management_api_v1/withdraws.rb
@@ -89,7 +89,7 @@ module ManagementAPIv1
       record = Withdraw.find_by!(params.slice(:tid))
       record.with_lock do
         { submitted: :submit,
-          cancelled: :cancel
+          canceled: :cancel
         }.each do |state, event|
           next unless params[:state] == state.to_s
           if record.aasm.may_fire_event?(event)


### PR DESCRIPTION
Version 1.7 Management API Cannot Cancel Withdraws #1232