### PR TITLE
Fix exploding market_ticker worker

### DIFF
--- a/app/workers/worker/market_ticker.rb
+++ b/app/workers/worker/market_ticker.rb
@@ -10,7 +10,7 @@ module Worker
       @tickers = Hash.new { |hash, market_id| initialize_market_data(market_id) }
       @trades  = Hash.new { |hash, market_id| initialize_market_data(market_id) }
       # NOTE: Update ticker only for enabled markets.
-      Market.enabled { |market| initialize_market_data(market) }
+      Market.enabled.find_each { |market| initialize_market_data(market) }
     end
 
     def process(payload, metadata, delivery_info)


### PR DESCRIPTION
After recent updates, the market ticker worker blows up with this error:

```
#<NoMethodError: undefined method `id' for "btcusd":String>
/peatio-workbench/app/peatio/app/workers/worker/market_ticker.rb:42:in `initialize_market_data'
/peatio-workbench/app/peatio/app/workers/worker/market_ticker.rb:10:in `block in initialize'
/peatio-workbench/app/peatio/app/workers/worker/market_ticker.rb:23:in `update_ticker'
/peatio-workbench/app/peatio/app/workers/worker/market_ticker.rb:18:in `process'
```