### PR TITLE
[WIP] Convox setup with AWS

### DIFF
--- a/.convox/app
+++ b/.convox/app
@@ -1,0 +1,1 @@
+exchange

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@
 .idea
 
 # Ignore docker
-Dockerfile
+# Dockerfile
 .dockerignore
 
 # Ignore CI related files

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,4 @@ tmp
 log
 .god
 
+.convox/

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: mysql2
-  encoding: utf8mb4
-  collation: utf8mb4_unicode_ci
+  encoding: utf8
+  collation: utf8_general_ci
   pool: 5
   host: <%= ENV['DATABASE_HOST'] || '127.0.0.1' %>
   port: 3306

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: mysql2
-  encoding: utf8
-  collation: utf8_general_ci
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   pool: 5
   host: <%= ENV['DATABASE_HOST'] || '127.0.0.1' %>
   port: 3306

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,13 +23,16 @@ defaults: &defaults
 development:
   <<: *defaults
   secret_key_base: ec7ffa7f1e53b586f2ad072518776a153b14f40ea77e5aa17b9b3ab5145ac29f018c2da13c626102b2d7c749b60f8fc81798579a7e820b96821d431b5fc144c3
+  secret_token: ec7ffa7f1e53b586f2ad072518776a153b14f40ea77e5aa17b9b3ab5145ac29f018c2da13c626102b2d7c749b60f8fc81798579a7e820b96821d431b5fc144c3
 
 test:
   <<: *defaults
   secret_key_base: 2c3cdc3e0bc14d5260250570be0961de2f974c4f3e15b6004734d9e587ce9f47da248f20dc1707a5bb555d879a5494641f4b1a01ca6066df2b783943914ebcd7
+  secret_token: 2c3cdc3e0bc14d5260250570be0961de2f974c4f3e15b6004734d9e587ce9f47da248f20dc1707a5bb555d879a5494641f4b1a01ca6066df2b783943914ebcd7
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   <<: *defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_token: <%= ENV["SECRET_KEY_BASE"] %>

--- a/convox.yml
+++ b/convox.yml
@@ -1,5 +1,9 @@
 resources:
   database:
     type: mysql
-  database:
-    type: s3
+services:
+  web:
+    build: .
+    port: 3000
+    resources:
+      - database

--- a/convox.yml
+++ b/convox.yml
@@ -3,6 +3,8 @@ services:
     build: .
     port: 3000
     scale: 2
+    resources:
+      - rabbitmq
   rabbitmq:
     image: rabbitmq:3.7.6-management
     port: 5672

--- a/convox.yml
+++ b/convox.yml
@@ -3,8 +3,3 @@ services:
     build: .
     port: 3000
     scale: 2
-    resources:
-      - rabbitmq
-  rabbitmq:
-    image: rabbitmq:3.7.6-management
-    port: 5672

--- a/convox.yml
+++ b/convox.yml
@@ -2,11 +2,7 @@ services:
   web:
     build: .
     port: 3000
-  db:
-    image: mysql:5.7
-    environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-    port: 3306
+    scale: 2
   rabbitmq:
     image: rabbitmq:3.7.6-management
     port: 5672

--- a/convox.yml
+++ b/convox.yml
@@ -1,9 +1,4 @@
-resources:
-  database:
-    type: mysql
 services:
   web:
     build: .
     port: 3000
-    resources:
-      - database

--- a/convox.yml
+++ b/convox.yml
@@ -4,6 +4,8 @@ services:
     port: 3000
   db:
     image: mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     port: 3306
   rabbitmq:
     image: rabbitmq:3.7.6-management

--- a/convox.yml
+++ b/convox.yml
@@ -1,0 +1,3 @@
+resources:
+  database:
+    type: mysql

--- a/convox.yml
+++ b/convox.yml
@@ -5,7 +5,7 @@ services:
   db:
     image: mysql:5.7
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     port: 3306
   rabbitmq:
     image: rabbitmq:3.7.6-management

--- a/convox.yml
+++ b/convox.yml
@@ -3,3 +3,5 @@ services:
     build: .
     port: 3000
     scale: 2
+    environment:
+      - '*'

--- a/convox.yml
+++ b/convox.yml
@@ -2,3 +2,9 @@ services:
   web:
     build: .
     port: 3000
+  db:
+    image: mysql:5.7
+    port: 3306
+  rabbitmq:
+    image: rabbitmq:3.7.6-management
+    port: 5672

--- a/convox.yml
+++ b/convox.yml
@@ -1,3 +1,5 @@
 resources:
   database:
     type: mysql
+  database:
+    type: s3


### PR DESCRIPTION
# AWS deployment with Convox

!!! This is work in progress

## Info
Unfortunately, deploying with GCP is not our option.

We're trying to automate our DevOps pipeline by using convox.com services. It's not that easy, but it's easier then doing Kubernetics/manual AWS setup.

## Notes on deploy process

- Change DATABASE_URL value protocol part from`mysql://` to `mysql2://`
- Make sure not to load schema, but bootstrap your project with rake db:migrate command. Or you'll have a chance of rake db:seed failing ( see https://github.com/rubykube/peatio/issues/672 )
- Don't provide mysql instance in resource section on convox.yml, just use `convox resource create mysql` and retrieve `mysql://` value
- convox.yml should contain explicitly defined ENV variables allowed to be set
- Don't set multi-regions availability. But be sure to provide proper region in convox (Singapore in ourcase)
- Don't scale down or up default number of web services (i suggest using 2, convox does 3 by default) -- this brakes things. Try auto-scale.