### PR TITLE
Redirect logs to stdout if ENV variable is present

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,13 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
+
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 


### PR DESCRIPTION
By default Rails writes its logs to a specific file, which is convenient if you only have one log file to tail. When you start scaling to multiple instances running your app, finding a single request or failure across multiple files becomes much harder. Storing logs on disk can also take down a server if the hard drive fills up. 

12 Factor recommend to redirect all logs to `stdout` -> https://www.12factor.net/logs . I propose to add ENV variable that would add such ability.