### PR TITLE
Informative message when POST /api/v2/orders with wrong volume (closes #1438)

### DIFF
--- a/app/api/api_v2/errors.rb
+++ b/app/api/api_v2/errors.rb
@@ -64,6 +64,12 @@ module APIv2
     end
   end
 
+  class CreateOrderAccountError < Error
+    def initialize(e)
+      super code: 2005, text: 'Not enough funds to create order.', status: 422
+    end
+  end
+
   class DepositByTxidNotFoundError < Error
     def initialize(txid)
       super code: 2012, text: "Deposit##txid=#{txid} doesn't exist.", status: 404

--- a/app/api/api_v2/helpers.rb
+++ b/app/api/api_v2/helpers.rb
@@ -66,6 +66,9 @@ module APIv2
       order = build_order(attrs)
       Ordering.new(order).submit
       order
+    rescue Account::AccountError => e
+      report_exception_to_screen(e)
+      raise CreateOrderAccountError, e.inspect
     rescue => e
       report_exception_to_screen(e)
       raise CreateOrderError, e.inspect

--- a/app/api/api_v2/named_params.rb
+++ b/app/api/api_v2/named_params.rb
@@ -14,9 +14,11 @@ module APIv2
 
     params :order do
       requires :side,     type: String, values: %w(sell buy), desc: -> { APIv2::Entities::Order.documentation[:side] }
-      requires :volume,   type: String, desc: -> { APIv2::Entities::Order.documentation[:volume] }
-      optional :price,    type: String, desc: -> { APIv2::Entities::Order.documentation[:price] }
+      requires :volume,   type: Float, desc: -> { APIv2::Entities::Order.documentation[:volume] }
       optional :ord_type, type: String, values: -> { Order::TYPES }, default: 'limit', desc: -> { APIv2::Entities::Order.documentation[:type] }
+      given ord_type: ->(val) { val == 'limit' } do
+        requires :price, type: Float, desc: -> { APIv2::Entities::Order.documentation[:price] }
+      end
     end
 
     params :order_id do

--- a/spec/api/api_v2/orders_spec.rb
+++ b/spec/api/api_v2/orders_spec.rb
@@ -178,20 +178,20 @@ describe APIv2::Orders, type: :request do
       old_count = OrderAsk.count
       api_post '/api/v2/orders', token: token, params: { market: 'btcusd', side: 'sell', volume: '12.13', price: '2014' }
       expect(response.code).to eq '422'
-      expect(response.body).to eq '{"error":{"code":2002,"message":"Failed to create order."}}'
+      expect(response.body).to eq '{"error":{"code":2005,"message":"Not enough funds to create order."}}'
       expect(OrderAsk.count).to eq old_count
     end
 
     it 'should give a number as volume parameter' do
       api_post '/api/v2/orders', token: token, params: { market: 'btcusd', side: 'sell', volume: 'test', price: '2014' }
       expect(response.code).to eq '422'
-      expect(response.body).to eq '{"error":{"code":2002,"message":"Failed to create order."}}'
+      expect(response.body).to eq '{"error":{"code":1001,"message":"volume is invalid"}}'
     end
 
     it 'should give a number as price parameter' do
       api_post '/api/v2/orders', token: token, params: { market: 'btcusd', side: 'sell', volume: '12.13', price: 'test' }
       expect(response.code).to eq '422'
-      expect(response.body).to eq '{"error":{"code":2002,"message":"Failed to create order."}}'
+      expect(response.body).to eq '{"error":{"code":1001,"message":"price is invalid"}}'
     end
   end
 


### PR DESCRIPTION
Informative message when POST /api/v2/orders with wrong volume #1438