### PR TITLE
Drop spaces from admins list

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -54,7 +54,7 @@ class Member < ActiveRecord::Base
     end
 
     def admins
-      Figaro.env.admin.split(',')
+      Figaro.env.admin.split(',').map(&:squish)
     end
 
     def search(field: nil, term: nil)


### PR DESCRIPTION
I found a bug when I put my email in admins list and I wondered why I'm not admin anymore.
I just put additional space in it