### PR TITLE
Skip creating keypair in bin/setup if set in env

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,8 +17,10 @@ Dir.chdir APP_ROOT do
   system 'rm -f log/* log/daemons/*'
   system 'bin/rake tmp:clear tmp:create'
 
-  puts "\n=== Creating secrets"
-  system "bundle exec peatio security keygen --path=config/secrets"
+  if ENV['JWT_PUBLIC_KEY'].nil?
+    puts "\n=== Creating secrets"
+    system "bundle exec peatio security keygen --path=config/secrets"
+  end
 
   puts "\n=== Starting backends"
   system "docker-compose -f config/backend.yml up -d"


### PR DESCRIPTION
e.g. when running it from the workbench