### PR TITLE
Parity Support instead of Geth

### DIFF
--- a/config/initializers/versioning.rb
+++ b/config/initializers/versioning.rb
@@ -5,9 +5,9 @@
 
 module Peatio
   class Application
-    GIT_TAG =    '2.0.0-alpha'
-    GIT_SHA =    '09b27c8b'
-    BUILD_DATE = 'Mon Nov 26 17:28:11 EET 2018'
+    GIT_TAG =    '1.9.1-rc.27'
+    GIT_SHA =    '5080dd7'
+    BUILD_DATE = 'Mon Nov 26 15:49:50 UTC 2018'
     VERSION =    GIT_TAG
   end
 end

--- a/docs/Parity.md
+++ b/docs/Parity.md
@@ -1,0 +1,46 @@
+### Install Nginx + fcgi
+
+    sudo apt install nginx -y fcgiwrap
+
+copy default file to /etc/nginx/sites-enabled/default
+
+    sudo systemctl restart nginx
+
+### files are available here:
+`https://github.com/muhammednagy/peatio/tree/stable/eth`
+### cgi files
+
+copy the cgi files to /var/www/html/cgi-bin and update total.cgi with your username
+
+    sudo chown www-data:www-data -R /var/www/html/cgi-bin
+    sudo chmod +x /var/www/html/cgi-bin/*
+
+### Install filter service
+copy total.js to /var/www
+
+    sudo chown www-data:www-data /var/www/total.js
+don't forget to edit service.rb with your url
+
+    sudo apt-get install git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev python-software-properties libffi-dev nodejs ruby-all-dev ruby
+    sudo gem install web3 -v 0.1.0
+    sudo gem install httparty
+copy service.rb file to /home/ubuntu/
+
+don't forget to update the username in filter.service
+copy filter.service file to /etc/systemd/system/filter.service
+
+    sudo systemctl start filter
+    sudo systemctl enable filter
+
+
+###Run Parity
+
+#Steps to setup Parity:
+
+1. wget https://releases.parity.io/v2.2.1/x86_64-unknown-linux-gnu/parity
+2. chmod +x parity
+3. sudo mv parity /usr/loca/bin
+Sync parity :
+4. parity --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth
+ for testnet :
+parity --chain ropsten --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth

--- a/docs/Parity.md
+++ b/docs/Parity.md
@@ -37,10 +37,10 @@ copy filter.service file to /etc/systemd/system/filter.service
 
 #Steps to setup Parity:
 
-1. wget https://releases.parity.io/v2.2.1/x86_64-unknown-linux-gnu/parity
-2. chmod +x parity
-3. sudo mv parity /usr/loca/bin
+1. `wget https://releases.parity.io/v2.2.1/x86_64-unknown-linux-gnu/parity`
+2. `chmod +x parity`
+3. `sudo mv parity /usr/loca/bin`
 Sync parity :
-4. parity --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth
- for testnet :
-parity --chain ropsten --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth
+4. `parity --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth`
+5.For testnet :
+`parity --chain ropsten --jsonrpc-interface=0.0.0.0 --jsonrpc-apis eth,personal,net,web3,rpc --geth`

--- a/docs/api/management_api_v1.md
+++ b/docs/api/management_api_v1.md
@@ -2,7 +2,7 @@ Management API v1
 =================
 Management API is server-to-server API with high privileges.
 
-**Version:** 2.0.0-alpha
+**Version:** 1.9.1-rc.27
 
 **License:** https://github.com/rubykube/peatio/blob/master/LICENSE.md
 

--- a/docs/api/member_api_v2.md
+++ b/docs/api/member_api_v2.md
@@ -2,7 +2,7 @@ Member API v2
 =============
 Member API is API which can be used by client application like SPA.
 
-**Version:** 2.0.0-alpha
+**Version:** 1.9.1-rc.27
 
 **Contact information:**  
 peatio.tech  

--- a/lib/blockchain_client/ethereum.rb
+++ b/lib/blockchain_client/ethereum.rb
@@ -132,7 +132,7 @@ module BlockchainClient
     end
 
     def permit_transaction(issuer, recipient)
-      json_rpc(:personal_unlockAccount, [normalize_address(issuer.fetch(:address)), issuer.fetch(:secret), 5]).tap do |response|
+      json_rpc(:personal_unlockAccount, [normalize_address(issuer.fetch(:address)), issuer.fetch(:secret), '0x5']).tap do |response|
         unless response['result']
           raise BlockchainClient::Error, \
             "#{currency.code.upcase} withdrawal from #{normalize_address(issuer[:address])} to #{normalize_address(recipient[:address])} is not permitted."

--- a/lib/wallet_client/geth.rb
+++ b/lib/wallet_client/geth.rb
@@ -61,7 +61,7 @@ module WalletClient
     end
 
     def permit_transaction(issuer, recipient)
-      json_rpc(:personal_unlockAccount, [normalize_address(issuer.fetch(:address)), issuer.fetch(:secret), 5]).tap do |response|
+      json_rpc(:personal_unlockAccount, [normalize_address(issuer.fetch(:address)), issuer.fetch(:secret), '0x5']).tap do |response|
         unless response['result']
           raise WalletClient::Error, \
             "#{wallet.name} withdrawal from #{normalize_address(issuer[:address])} to #{normalize_address(recipient[:address])} is not permitted."


### PR DESCRIPTION
You can use Parity with this branch
Parity is a best alternative of geth.
Parity takes less than 1 hour to sync from 0 to current block.
A request to rubykube team by me :
Start using parity instead of geth in future releases!
