### PR TITLE
Withdraw API With OTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
   - redis-server
   - rabbitmq
   - docker
+  - docker-compose
 
 # Execute all of the commands which need to be executed before installing dependencies.
 before_install:
@@ -32,6 +33,7 @@ before_install:
 
 # Execute all of the commands which should install application dependencies.
 install:
+  - docker-compose -f config/backend.yml up -d vault
   - bundle install --deployment --without production --jobs=$(nproc) --retry=3
   - bundle exec rake yarn:install
   - ./bin/install_plugins
@@ -39,6 +41,7 @@ install:
 # Execute all of the commands which need to be executed before running actual tests.
 before_script:
   - bundle exec rake db:create db:migrate
+  - ./bin/init_vault
 
 # Execute all of the commands which should make the build pass or fail.
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,8 @@ gem 'digest-sha3', '~> 1.1.0'
 gem 'scout_apm', '~> 2.4', require: false
 gem 'peatio', '~> 0.4.4'
 gem 'rack-cors', '~> 1.0.2', require: false
-gem 'env-tweaks', '~> 1.0.0', require: false
+gem 'env-tweaks', '~> 1.0.0'
+gem 'vault', '~> 0.12', require: false
 
 group :development, :test do
   gem 'bump',         '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.4.2)
       execjs
+    aws-sigv4 (1.0.3)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -376,6 +377,8 @@ GEM
       addressable
     validates_lengths_from_database (0.7.0)
       activerecord (>= 3)
+    vault (0.12.0)
+      aws-sigv4
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -456,6 +459,7 @@ DEPENDENCIES
   uglifier (~> 4.1.17)
   validate_url (~> 1.0.2)
   validates_lengths_from_database (~> 0.7.0)
+  vault (~> 0.12)
   webmock (~> 3.3)
 
 BUNDLED WITH

--- a/app/api/v2/helpers.rb
+++ b/app/api/v2/helpers.rb
@@ -28,6 +28,12 @@ module API
         end
       end
 
+      def withdraw_api_must_be_enabled!
+        if ENV.false?('ENABLE_ACCOUNT_WITHDRAWAL_API')
+          raise Error.new(text: 'Account withdrawal API is disabled', status: 422)
+        end
+      end
+
       def current_user
         # JWT authentication provides member email.
         if env.key?('api_v2.authentic_member_email')

--- a/bin/init_vault
+++ b/bin/init_vault
@@ -1,0 +1,7 @@
+DOCKER_VAULT_ID=`docker ps | grep vault  | awk '{ print $1 }'`
+
+docker exec ${DOCKER_VAULT_ID} sh -c \
+    "vault secrets disable secret \
+    && vault secrets enable -path=secret -version=1 kv \
+    && vault secrets enable totp"
+

--- a/bin/setup
+++ b/bin/setup
@@ -25,6 +25,9 @@ Dir.chdir APP_ROOT do
   puts "\n=== Starting backends"
   system "docker-compose -f config/backend.yml up -d"
 
+  puts "\n=== Setup Vault"
+  system "bin/init_vault"
+
   # in production we run db:setup as k8s jobs
   if ENV['RAILS_ENV'] == 'production'
     puts "\n=== Compiling assets ==="

--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,6 @@
 # This file is used by Rack-based servers to start the application.
 require ::File.expand_path('../config/environment', __FILE__)
 require 'rack/cors'
-require 'env-tweaks'
 
 map Rails.application.config.relative_url_root do
   use Rack::Cors do

--- a/config/backend.yml
+++ b/config/backend.yml
@@ -57,6 +57,16 @@ services:
         # Continue with the default entrypoint
         ./entrypoint.sh
 
+  vault:
+    image: vault:1.0.1
+    ports:
+      - "8200:8200"
+    environment:
+      SKIP_SETCAP: 1
+      VAULT_TOKEN: changeme
+      VAULT_DEV_ROOT_TOKEN_ID: changeme
+      VAULT_ADDR: http://vault:8200
+
 volumes:
   db_data:
   rabbitmq_data:

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+require 'vault/totp'
+
+Vault.configure do |config|
+  config.address = ENV.fetch('VAULT_URL', 'http://127.0.0.1:8200')
+  config.token = ENV.fetch('VAULT_TOKEN')
+  config.ssl_verify = false
+  config.timeout = 60
+end

--- a/config/templates/application.yml.erb
+++ b/config/templates/application.yml.erb
@@ -136,6 +136,13 @@ defaults: &defaults
 
   BULLET: 'false'
 
+  # Configuration to allow Withdraw via API i.e (POST api/v2/account/withdraws)
+  ENABLE_ACCOUNT_WITHDRAWAL_API: true
+
+  # Configure Vault to verify OTP for Withdraw API
+  VAULT_URL:    http://127.0.0.1:8200
+  VAULT_TOKEN:  changeme
+
 development:
   <<: *defaults
 

--- a/lib/vault/totp.rb
+++ b/lib/vault/totp.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'vault'
+
+module Vault
+  # Vault::TOTP helper
+  module TOTP
+    Error = Class.new(StandardError)
+
+    class <<self
+
+      def server_available?
+        read_data('sys/health').present?
+      rescue StandardError
+        false
+      end
+
+      def exist?(uid)
+        read_data(totp_key(uid)).present?
+      end
+
+      def validate?(uid, code)
+        return false unless exist?(uid)
+        write_data(totp_code_key(uid), code: code).data[:valid]
+      end
+
+      def with_human_error
+        raise ArgumentError, 'Block is required' unless block_given?
+        yield
+      rescue Vault::VaultError => e
+        Rails.logger.error { e }
+        if e.message.include?('connection refused')
+          raise Error, '2FA server is under maintenance'
+        end
+
+        if e.message.include?('code already used')
+          raise Error, 'This code was already used. Wait until the next time period'
+        end
+
+        raise e
+      end
+
+      private
+
+      def totp_key(uid)
+        "totp/keys/#{uid}"
+      end
+
+      def totp_code_key(uid)
+        "totp/code/#{uid}"
+      end
+
+      def read_data(key)
+        with_human_error do
+          vault.read(key)
+        end
+      end
+
+      def write_data(key, params)
+        with_human_error do
+          vault.write(key, params)
+        end
+      end
+
+      def vault
+        Vault.logical
+      end
+    end
+  end
+end

--- a/spec/api/v2/account/withdraws_spec.rb
+++ b/spec/api/v2/account/withdraws_spec.rb
@@ -6,52 +6,47 @@ describe API::V2::Account::Withdraws, type: :request do
   let(:token) { jwt_for(member) }
   let(:level_0_member) { create(:member, :level_0) }
   let(:level_0_member_token) { jwt_for(level_0_member) }
-  let(:btc_withdraws) { create_list(:btc_withdraw, 20, member: member) }
-  let(:usd_withdraws) { create_list(:usd_withdraw, 20, member: member) }
-
-  before do
-    # Force evaluate all.
-    btc_withdraws
-    usd_withdraws
-  end
 
   describe 'GET /api/v2/account/withdraws' do
-    it 'should require authentication' do
+    let!(:btc_withdraws) { create_list(:btc_withdraw, 20, member: member) }
+    let!(:usd_withdraws) { create_list(:usd_withdraw, 20, member: member) }
+
+    it 'require authentication' do
       get '/api/v2/account/withdraws'
       expect(response.code).to eq '401'
     end
 
-    it 'should validate currency param' do
+    it 'validates currency param' do
       api_get '/api/v2/account/withdraws', params: { currency: 'FOO' }, token: token
       expect(response.code).to eq '422'
       expect(response.body).to eq '{"error":{"code":1001,"message":"currency does not have a valid value"}}'
     end
 
-    it 'should validate page param' do
+    it 'validates page param' do
       api_get '/api/v2/account/withdraws', params: { page: -1 }, token: token
       expect(response.code).to eq '422'
       expect(response.body).to eq '{"error":{"code":1001,"message":"page page must be greater than zero."}}'
     end
 
-    it 'should validate limit param' do
+    it 'validates limit param' do
       api_get '/api/v2/account/withdraws', params: { limit: 9999 }, token: token
       expect(response.code).to eq '422'
       expect(response.body).to eq '{"error":{"code":1001,"message":"limit must be in range: 1..1000."}}'
     end
 
-    it 'should return withdraws for all currencies by default' do
+    it 'returns withdraws for all currencies by default' do
       api_get '/api/v2/account/withdraws', params: { limit: 1000 }, token: token
       expect(response).to be_success
       expect(JSON.parse(response.body).map { |x| x['currency'] }.uniq.sort).to eq %w[ btc usd ]
     end
 
-    it 'should return withdraws specified currency' do
+    it 'returns withdraws specified currency' do
       api_get '/api/v2/account/withdraws', params: { currency: 'BTC', limit: 1000 }, token: token
       expect(response).to be_success
       expect(JSON.parse(response.body).map { |x| x['currency'] }.uniq.sort).to eq %w[ btc ]
     end
 
-    it 'should paginate withdraws' do
+    it 'paginates withdraws' do
       ordered_withdraws = btc_withdraws.sort_by(&:id).reverse
 
       api_get '/api/v2/account/withdraws', params: { currency: 'BTC', limit: 10, page: 1 }, token: token
@@ -63,7 +58,7 @@ describe API::V2::Account::Withdraws, type: :request do
       expect(JSON.parse(response.body).first['id']).to eq ordered_withdraws[10].id
     end
 
-    it 'should sort withdraws' do
+    it 'sorts withdraws' do
       ordered_withdraws = btc_withdraws.sort_by(&:id).reverse
 
       api_get '/api/v2/account/withdraws', params: { currency: 'BTC', limit: 100 }, token: token
@@ -76,6 +71,122 @@ describe API::V2::Account::Withdraws, type: :request do
       api_get '/api/v2/account/withdraws', token: level_0_member_token
       expect(response.code).to eq '403'
       expect(JSON.parse(response.body)['error']).to eq( {'code' => 2000, 'message' => 'Please, pass the corresponding verification steps to withdraw funds.'} )
+    end
+  end
+
+  describe 'create withdraw' do
+    let(:currency) { Currency.coins.sample }
+    let(:amount) { 0.1575 }
+    let :data do
+      { uid:      member.uid,
+        currency: currency.code,
+        amount:   amount,
+        rid:      Faker::Bitcoin.address,
+        otp:      123456 }
+    end
+    let(:account) { member.accounts.with_currency(currency).first }
+    let(:balance) { 1.2 }
+    before { account.plus_funds(balance) }
+    before { Vault::TOTP.stubs(:validate?).returns(true) }
+
+    context 'fiat withdrawal' do
+      before { data[:currency] = Currency.fiats.pluck(:id).sample }
+      it 'doesn\'t allow fiat' do
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"currency does not have a valid value"}}'
+      end
+    end
+
+    context 'crypto withdrawal' do
+      context 'disabled account withdrawal API' do
+        before { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'false' }
+        after { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'true' }
+        it 'doesn\'t allow account withdrawal API call' do
+          api_post '/api/v2/account/withdraws', params: data, token: token
+          expect(response).to have_http_status(422)
+          expect(response.body).to eq '{"error":{"code":2000,"message":"Account withdrawal API is disabled"}}'
+        end
+      end
+
+      context 'extremely precise values' do
+        before { Currency.any_instance.stubs(:withdraw_fee).returns(BigDecimal(0)) }
+        before { Currency.any_instance.stubs(:precision).returns(16) }
+        it 'keeps precision for amount' do
+          currency.update!(precision: 16)
+          data[:amount] = '0.0000000123456789'
+          api_post '/api/v2/account/withdraws', params: data, token: token
+          expect(response).to have_http_status(201)
+          expect(Withdraw.last.sum.to_s).to eq data[:amount]
+        end
+      end
+
+      it 'validates missing otp param' do
+        data.except!(:otp)
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"otp is missing, otp is empty"}}'
+      end
+
+      it 'requires otp' do
+        data[:otp] = nil
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"otp is empty"}}'
+      end
+
+      it 'validates otp code' do
+        Vault::TOTP.stubs(:validate?).returns(false)
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":2000,"message":"OTP code is invalid"}}'
+      end
+
+      it 'requires amount' do
+        data[:amount] = nil
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"amount must be positive"}}'
+      end
+
+      it 'validates negative balance' do
+        data[:amount] = -1
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"amount must be positive"}}'
+      end
+
+      it 'validates enough balance' do
+        data[:amount] = 100
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"errors":["Account balance is insufficient"]}'
+      end
+
+      it 'requires rid' do
+        data[:rid] = nil
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"rid is empty"}}'
+      end
+
+      it 'requires currency' do
+        data[:currency] = nil
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(422)
+        expect(response.body).to eq '{"error":{"code":1001,"message":"currency does not have a valid value"}}'
+      end
+
+      it 'creates new withdraw and immediately submits it' do
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(201)
+        record = Withdraw.last
+        expect(record.sum).to eq 0.1575
+        expect(record.aasm_state).to eq 'submitted'
+        expect(record.account).to eq account
+        expect(record.account.balance).to eq(1.2 - amount)
+        expect(record.account.locked).to eq amount
+      end
     end
   end
 end

--- a/spec/api/v2/cors/cors_spec.rb
+++ b/spec/api/v2/cors/cors_spec.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'rack/cors'
-require 'env-tweaks'
 
 describe Rack::Cors, type: :request do
 

--- a/spec/lib/vault_totp_spec.rb
+++ b/spec/lib/vault_totp_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe Vault::TOTP do
+  let(:uid) { 'uid' }
+  let(:email) { 'email' }
+
+  describe '.with_human_error' do
+    it 'renders human error when vault is down' do
+      expect do
+        described_class.with_human_error do
+          raise Vault::VaultError, 'Message connection refused message'
+        end
+      end.to raise_error(described_class::Error, '2FA server is under maintenance')
+    end
+
+    it 'renders human error when code was used twice' do
+      expect do
+        described_class.with_human_error do
+          raise Vault::VaultError, 'Message code already used message'
+        end
+      end.to raise_error(described_class::Error,
+                         'This code was already used. Wait until the next time period')
+    end
+
+    it 'renders error when called without block' do
+      expect do
+        described_class.with_human_error
+      end.to raise_error(ArgumentError, 'Block is required')
+    end
+  end
+
+  describe '.exist?' do
+    before { described_class.stubs(:read_data).with('totp/keys/uid').returns( ['data'] ) }
+    it 'creates secret' do
+      described_class.exist?(uid)
+    end
+  end
+
+  describe '.validate?' do
+    before do
+      described_class.stubs(:write_data).returns( OpenStruct.new({data: data}) )
+      described_class.stubs(:read_data).returns( OpenStruct.new({data: data}) )
+    end
+    let(:data) { { valid: true } }
+
+    subject { described_class.validate?(uid, 'code') }
+
+    context 'when not exist' do
+      before { described_class.stubs(:exist?).returns( false ) }
+      it { is_expected.to eq false }
+    end
+
+    context 'when valid' do
+      before { described_class.stubs(:exist?).returns( true ) }
+      it { is_expected.to eq true }
+    end
+
+    context 'when invalid' do
+      before { described_class.stubs(:exist?).returns( true ) }
+      let(:data) { { valid: false } }
+      it { is_expected.to eq false }
+    end
+  end
+end


### PR DESCRIPTION
* Add POST /api/v2/account/
* Integrate Vault to travis & 
* Integrate Vault::TOTP 
* Add ENABLE_ACCOUNT_WITHDRAWAL_API, VAULT_URL & VAULT_TOKEN envs
    
Co-authored-by: Yaroslav Savchuk <ysavchuk@heliostech.fr>
Co-authored-by: Dinesh Chohda <dinesh.skyach@gmail.com>