### PR TITLE
Publish WS event on k-line updates. Improve k-daemon performance

### DIFF
--- a/docs/api/websocket_api.md
+++ b/docs/api/websocket_api.md
@@ -18,6 +18,7 @@ GET request parameters:
 List of supported public streams:
 * [`<market>.update`](#update) (global state updates)
 * [`<market>.trades` ](#trades)
+* [`<market>.kline-PERIOD` ](#kline-point) (available periods are "1m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d", "3d", "1w")
 * [`global.tickers`](#tickers)
 
 List of supported private streams (requires authentication):
@@ -134,6 +135,24 @@ Here is structure of `<market.trades>` event expose as array with trades:
 | `price`  | Price for the trade.                   |
 | `amount` | The amount of trade.                   |
 | `date`   | Trade create time.                     |
+
+#### Kline point
+
+Kline point as array of numbers:
+
+1. Timestamp.
+2. Open price.
+3. Max price.
+4. Min price.
+5. Last price.
+6. Period volume
+
+Example:
+
+```ruby
+[1537370580, 0.0839, 0.0921, 0.0781, 0.0845, 0.5895]
+```
+
 
 #### Tickers
 

--- a/spec/api/api_v2/k_spec.rb
+++ b/spec/api/api_v2/k_spec.rb
@@ -4,6 +4,7 @@
 describe APIv2::K, type: :request do
   describe 'GET /api/v2/k' do
     let(:points) do
+      # [timestamp, open_price, max_price, min_price, last_price, period_volume]
       [[1537370460, 0.7079, 0.2204, 0.9794, 0.5273, 0.0747],
        [1537370520, 0.6293, 0.5054, 0.2253, 0.1969, 0.7276],
        [1537370580, 0.0939, 0.1949, 0.0032, 0.8328, 0.5895],


### PR DESCRIPTION
* Publish MQ event on  #update_point or #append_point
* Update WS API doc
* Skip unnecessary k point updates
* Use lset instead of pop & push
* Add TODO to k.rb
* Add k-line comments
* KLineService #humanize_period(period)

closes #1995