### PR TITLE
Average 24h price using VWAP ratio. Minor Global & Market refactor

### DIFF
--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -21,6 +21,8 @@
 class Market < ActiveRecord::Base
 
   attr_readonly :ask_unit, :bid_unit, :ask_precision, :bid_precision
+  delegate :bids, :asks, :trades, :ticker, :h24_volume, :avg_h24_price,
+           to: :global
 
   scope :ordered, -> { order(position: :asc) }
   scope :enabled, -> { where(enabled: true) }
@@ -40,7 +42,7 @@ class Market < ActiveRecord::Base
 
   validates :min_ask_amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :min_bid_amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  
+
   before_validation(on: :create) { self.id = "#{ask_unit}#{bid_unit}" }
 
   validate :must_not_disable_all_markets, on: :update
@@ -85,12 +87,6 @@ class Market < ActiveRecord::Base
   def fix_number_precision(type, d)
     d.round send("#{type}_precision"), BigDecimal::ROUND_DOWN
   end
-
-  # shortcut of global access
-  def bids;   global.bids   end
-  def asks;   global.asks   end
-  def trades; global.trades end
-  def ticker; global.ticker end
 
   def unit_info
     {name: name, base_unit: ask_unit, quote_unit: bid_unit}

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -26,7 +26,7 @@ class Trade < ActiveRecord::Base
 
   class << self
     def latest_price(market)
-      with_market(market).order(id: :desc).select(:price).first.try(:price) || 0.to_d
+      with_market(market).order(id: :desc).pluck(:price).first.to_d
     end
 
     def filter(market, timestamp, from, to, limit, order)
@@ -43,10 +43,6 @@ class Trade < ActiveRecord::Base
       trades.each do |trade|
         trade.side = trade.ask_member_id == member.id ? 'ask' : 'bid'
       end
-    end
-
-    def avg_h24_price(market)
-      with_market(market).h24.select(:price).average(:price).to_d
     end
   end
 

--- a/spec/api/v2/public/markets_spec.rb
+++ b/spec/api/v2/public/markets_spec.rb
@@ -295,9 +295,8 @@ describe API::V2::Public::Markets, type: :request do
   end
 
   describe 'GET /api/v2/markets/tickers' do
-    # Clear Redis before each example.
-    before { Rails.cache.instance_variable_get(:@data).flushall }
-    after { Rails.cache.instance_variable_get(:@data).flushall }
+    before { clear_redis }
+    after { clear_redis }
 
     context 'no trades executed yet' do
       let(:expected_ticker) do
@@ -348,7 +347,7 @@ describe API::V2::Public::Markets, type: :request do
           'low' => '5.0', 'high' => '6.0',
           'open' => '6.0', 'last' => '6.0',
           'vol' => '2.0', 'volume' => '2.0',
-          'avg_price' => '5.5', 'price_change_percent' => '+0.00%' }
+          'avg_price' => '5.45', 'price_change_percent' => '+0.00%' }
       end
       before do
         Worker::MarketTicker.new.process(trade1.as_json, nil, nil)
@@ -365,9 +364,8 @@ describe API::V2::Public::Markets, type: :request do
   end
 
   describe 'GET /api/v2/public/markets/:market/tickers' do
-    # Clear Redis before each example.
-    before { Rails.cache.instance_variable_get(:@data).flushall }
-    after { Rails.cache.instance_variable_get(:@data).flushall }
+    before { clear_redis }
+    after { clear_redis }
     context 'no trades executed yet' do
       let(:expected_ticker) do
         { 'buy' => '0.0', 'sell' => '0.0',
@@ -415,7 +413,7 @@ describe API::V2::Public::Markets, type: :request do
           'low' => '5.0', 'high' => '6.0',
           'open' => '6.0', 'last' => '6.0',
           'vol' => '2.0', 'volume' => '2.0',
-          'avg_price' => '5.5', 'price_change_percent' => '+0.00%' }
+          'avg_price' => '5.45', 'price_change_percent' => '+0.00%' }
       end
       before do
         Worker::MarketTicker.new.process(trade1.as_json, nil, nil)

--- a/spec/models/global_spec.rb
+++ b/spec/models/global_spec.rb
@@ -1,6 +1,84 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 
-describe Global do
-  let(:global) { Global[:btcusd] }
+describe Global, '.avg_h24_price' do
+
+  before { clear_redis }
+  after { clear_redis }
+  
+  let(:market) { Market.all.sample }
+  let(:global) { Global[market] }
+  context 'no trades executed' do
+    it 'returns 0' do
+      expect(global.avg_h24_price).to eq 0.to_d
+    end
+  end
+
+  context 'no trades executed for last 24 hours' do
+    let!(:trades) { create_list(:trade, 10, market: market, created_at: 24.hours.ago - 1) }
+    it 'returns 0' do
+      expect(global.avg_h24_price).to eq 0.to_d
+    end
+  end
+
+  context 'single trade executed during last 24 hours' do
+    let!(:trade) { create(:trade, market: market, price: 5, volume: 2) }
+    it 'returns trade price' do
+      expect(global.avg_h24_price).to eq trade.price
+    end
+  end
+
+  context 'multiple trades executed during last 24 hours' do
+    def calculate_vwap(trades)
+      total_volume = trades.sum { |t| t.volume }
+      trades.sum { |t| t.price * t.volume } / total_volume
+    end
+
+    let(:trades_price_volume) do
+      [
+        { price: 12.to_d, volume: 10.to_d },
+        { price: 11.to_d, volume: 17.to_d },
+        { price: 10.to_d, volume: 25.to_d },
+        { price:  9.to_d, volume: 18.to_d },
+        { price:  8.to_d, volume: 10.to_d }
+      ]
+    end
+
+    let(:vwap) do
+      calculate_vwap(trades.to_a)
+    end
+
+    let!(:trades) do
+      trades_price_volume.each do |h|
+        create(:trade, market: market, price: h[:price], volume: h[:volume])
+      end
+      Trade.where(market: market)
+    end
+
+    it 'returns VWAP' do
+      expect(global.avg_h24_price).to eq vwap
+    end
+
+    context 'new trade added' do
+      let(:old_vwap) { vwap }
+
+      it 'caches VWAP' do
+        expect(global.avg_h24_price).to eq old_vwap
+        create(:trade, market: market, price: 15, volume: 20)
+        expect(global.avg_h24_price).to eq old_vwap
+      end
+
+      it 'updates VWAP after redis clear' do
+        expect(global.avg_h24_price).to eq old_vwap
+        new_trade = create(:trade, market: market, price: 15, volume: 20)
+
+        updated_trades = [*trades, new_trade]
+        new_vwap = calculate_vwap(updated_trades)
+        clear_redis
+
+        expect(old_vwap).to_not eq new_vwap
+        expect(global.avg_h24_price).to eq new_vwap
+      end
+    end
+  end
 end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -30,23 +30,32 @@ describe Market do
     end
   end
 
+  # TODO: Find better way for delegation testing.
   context 'shortcut of global access' do
-    let(:log) { Market.find(:btcusd) }
+    let(:market) { Market.find(:btcusd) }
 
     it 'bids' do
-      expect(log.bids).to be
+      expect(market.bids).to eq market.global.bids
     end
 
     it 'asks' do
-      expect(log.asks).to be
+      expect(market.asks).to eq market.global.asks
     end
 
     it 'trades' do
-      expect(log.trades).to be
+      expect(market.trades).to eq market.global.trades
     end
 
     it 'ticker' do
-      expect(log.ticker).to be
+      expect(market.ticker).to eq market.global.ticker
+    end
+
+    it 'h24_volume' do
+      expect(market.h24_volume).to eq market.global.h24_volume
+    end
+
+    it 'avg_h24_price' do
+      expect(market.avg_h24_price).to eq market.global.avg_h24_price
     end
   end
 

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -12,7 +12,7 @@ describe Trade, '.latest_price' do
   end
 end
 
-describe Trade, '.collect_side' do
+describe Trade, '.for_member' do
   let(:member) { create(:member, :level_3) }
   let(:ask)    { create(:order_ask, member: member) }
   let(:bid)    { create(:order_bid, member: member) }

--- a/spec/support/redis_helper.rb
+++ b/spec/support/redis_helper.rb
@@ -1,0 +1,10 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module RedisTestHelper
+  def clear_redis
+    Rails.cache.instance_variable_get(:@data).flushall
+  end
+end
+
+RSpec.configure { |config| config.include RedisTestHelper }


### PR DESCRIPTION
* Calculate average 24 hours price using VWAP ratio
* Move #avg_24h_price from Trade to Global
* Update caching for #avg_h24_price and #h24_volume
* Refactor Global #key
* Use delegate instead of single-line method in Market
* Add RedisTestHelper Rspec Helper
* Global #avg_h24_price specs
* Update Market delegation specs

closes #2001