### PR TITLE
Prevent admin to create mirror market pairs. Update seeds

### DIFF
--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -29,6 +29,7 @@ class Market < ActiveRecord::Base
   scope :with_base_unit, -> (base_unit){ where(ask_unit: base_unit) }
 
   validate { errors.add(:ask_unit, :invalid) if ask_unit == bid_unit }
+  validate { errors.add(:id, :taken) if Market.where(ask_unit: bid_unit, bid_unit: ask_unit).present? }
   validates :id, uniqueness: { case_sensitive: false }, presence: true
   validates :ask_unit, :bid_unit, presence: true
   validates :ask_fee, :bid_fee, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 0.5 }

--- a/config/templates/seed/markets.yml.erb
+++ b/config/templates/seed/markets.yml.erb
@@ -1,104 +1,6 @@
 <% if ENV['MARKETS_CONFIG'] %>
 <%= File.read(ENV['MARKETS_CONFIG']) %>
 <% else %>
-- id:             usdbtc
-  ask_unit:       usd
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       100
-  enabled:        true
-
-- id:             usdxrp
-  ask_unit:       usd
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       101
-  enabled:        true
-
-- id:             usdbch
-  ask_unit:       usd
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       102
-  enabled:        true
-
-- id:             usdltc
-  ask_unit:       usd
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       103
-  enabled:        true
-
-- id:             usddash
-  ask_unit:       usd
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0  
-  ask_precision:  4
-  bid_precision:  4
-  position:       104
-  enabled:        true
-
-- id:             usdeth
-  ask_unit:       usd
-  bid_unit:       eth
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       105
-  enabled:        true
-  
-- id:             usdtrst
-  ask_unit:       usd
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0  
-  ask_precision:  4
-  bid_precision:  4
-  position:       106
-  enabled:        true
-  
 - id:             btcusd
   ask_unit:       btc
   bid_unit:       usd
@@ -110,93 +12,8 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       200
+  position:       100
   enabled:        true
-  
-- id:             btcxrp
-  ask_unit:       btc
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       201
-  enabled:        true
-  
-- id:             btcbch
-  ask_unit:       btc
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       202
-  enabled:        true
-  
-- id:             btcltc
-  ask_unit:       btc
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       203
-  enabled:        true
-  
-- id:             btcdash
-  ask_unit:       btc
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       204
-  enabled:        true
-  
-- id:             btceth
-  ask_unit:       btc
-  bid_unit:       eth
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       205
-  enabled:        true
-  
-- id:             btctrst
-  ask_unit:       btc
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       206
-  enabled:        true
-  
 - id:             xrpusd
   ask_unit:       xrp
   bid_unit:       usd
@@ -208,7 +25,73 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       300
+  position:       101
+  enabled:        true
+- id:             bchusd
+  ask_unit:       bch
+  bid_unit:       usd
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0
+  ask_precision:  4
+  bid_precision:  4
+  position:       102
+  enabled:        true
+- id:             ltcusd
+  ask_unit:       ltc
+  bid_unit:       usd
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0
+  ask_precision:  4
+  bid_precision:  4
+  position:       103
+  enabled:        true
+- id:             dashusd
+  ask_unit:       dash
+  bid_unit:       usd
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0  
+  ask_precision:  4
+  bid_precision:  4
+  position:       104
+  enabled:        true
+- id:             ethusd
+  ask_unit:       eth
+  bid_unit:       usd
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0
+  ask_precision:  4
+  bid_precision:  4
+  position:       105
+  enabled:        true
+  
+- id:             trstusd
+  ask_unit:       trst
+  bid_unit:       usd
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0  
+  ask_precision:  4
+  bid_precision:  4
+  position:       106
   enabled:        true
   
 - id:             xrpbtc
@@ -222,12 +105,12 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       301
+  position:       201
   enabled:        true
   
-- id:             xrpbch
-  ask_unit:       xrp
-  bid_unit:       bch
+- id:             bchbtc
+  ask_unit:       bch
+  bid_unit:       btc
   ask_fee:        0.0015
   bid_fee:        0.0015
   min_ask_price:  0.0
@@ -236,12 +119,12 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       302
+  position:       202
   enabled:        true
   
-- id:             xrpltc
-  ask_unit:       xrp
-  bid_unit:       ltc
+- id:             ltcbtc
+  ask_unit:       ltc
+  bid_unit:       btc
   ask_fee:        0.0015
   bid_fee:        0.0015
   min_ask_price:  0.0
@@ -250,12 +133,12 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       303
+  position:       203
   enabled:        true
   
-- id:             xrpdash
-  ask_unit:       xrp
-  bid_unit:       dash
+- id:             dashbtc
+  ask_unit:       dash
+  bid_unit:       btc
   ask_fee:        0.0015
   bid_fee:        0.0015
   min_ask_price:  0.0
@@ -264,7 +147,35 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       304
+  position:       204
+  enabled:        true
+  
+- id:             ethbtc
+  ask_unit:       eth
+  bid_unit:       btc
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0
+  ask_precision:  4
+  bid_precision:  4
+  position:       205
+  enabled:        true
+  
+- id:             trstbtc
+  ask_unit:       trst
+  bid_unit:       btc
+  ask_fee:        0.0015
+  bid_fee:        0.0015
+  min_ask_price:  0.0
+  max_bid_price:  0.0
+  min_ask_amount: 0.0
+  min_bid_amount: 0.0
+  ask_precision:  4
+  bid_precision:  4
+  position:       206
   enabled:        true
   
 - id:             xrpeth
@@ -280,91 +191,6 @@
   bid_precision:  4
   position:       305
   enabled:        true
-
-- id:             xrptrst
-  ask_unit:       xrp
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       306
-  enabled:        true
-
-- id:             bchusd
-  ask_unit:       bch
-  bid_unit:       usd
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       400
-  enabled:        true
-
-- id:             bchbtc
-  ask_unit:       bch
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       401
-  enabled:        true
-
-- id:             bchxrp
-  ask_unit:       bch
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       402
-  enabled:        true
-
-- id:             bchltc
-  ask_unit:       bch
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       403
-  enabled:        true
-
-- id:             bchdash
-  ask_unit:       bch
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       404
-  enabled:        true
-
 - id:             bcheth
   ask_unit:       bch
   bid_unit:       eth
@@ -378,91 +204,6 @@
   bid_precision:  4
   position:       405
   enabled:        true
-
-- id:             bchtrst
-  ask_unit:       bch
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       406
-  enabled:        true
-
-- id:             ltcusd
-  ask_unit:       ltc
-  bid_unit:       usd
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       500
-  enabled:        true
-
-- id:             ltcbtc
-  ask_unit:       ltc
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       501
-  enabled:        true
-
-- id:             ltcxrp
-  ask_unit:       ltc
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       502
-  enabled:        true
-
-- id:             ltcbch
-  ask_unit:       ltc
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       503
-  enabled:        true
-
-- id:             ltcdash
-  ask_unit:       ltc
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       504
-  enabled:        true
-
 - id:             ltceth
   ask_unit:       ltc
   bid_unit:       eth
@@ -476,91 +217,6 @@
   bid_precision:  4
   position:       505
   enabled:        true
-
-- id:             ltctrst
-  ask_unit:       ltc
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       506
-  enabled:        true
-
-- id:             dashusd
-  ask_unit:       dash
-  bid_unit:       usd
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       600
-  enabled:        true
-
-- id:             dashbtc
-  ask_unit:       dash
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       601
-  enabled:        true
-
-- id:             dashxrp
-  ask_unit:       dash
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       602
-  enabled:        true
-
-- id:             dashbch
-  ask_unit:       dash
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       603
-  enabled:        true
-
-- id:             dashltc
-  ask_unit:       dash
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       604
-  enabled:        true
-
 - id:             dasheth
   ask_unit:       dash
   bid_unit:       eth
@@ -574,203 +230,6 @@
   bid_precision:  4
   position:       605
   enabled:        true
-
-- id:             dashtrst
-  ask_unit:       dash
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       606
-  enabled:        true
-
-- id:             ethusd
-  ask_unit:       eth
-  bid_unit:       usd
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       700
-  enabled:        true
-
-- id:             ethbtc
-  ask_unit:       eth
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       701
-  enabled:        true
-
-- id:             ethxrp
-  ask_unit:       eth
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       702
-  enabled:        true
-
-- id:             ethbch
-  ask_unit:       eth
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       703
-  enabled:        true
-
-- id:             ethltc
-  ask_unit:       eth
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       704
-  enabled:        true
-
-- id:             ethdash
-  ask_unit:       eth
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       705
-  enabled:        true
-
-- id:             ethtrst
-  ask_unit:       eth
-  bid_unit:       trst
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       706
-  enabled:        true
-
-- id:             trstusd
-  ask_unit:       trst
-  bid_unit:       usd
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       800
-  enabled:        true
-
-- id:             trstbtc
-  ask_unit:       trst
-  bid_unit:       btc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       801
-  enabled:        true
-
-- id:             trstxrp
-  ask_unit:       trst
-  bid_unit:       xrp
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       802
-  enabled:        true
-
-- id:             trstbch
-  ask_unit:       trst
-  bid_unit:       bch
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       803
-  enabled:        true
-
-- id:             trstltc
-  ask_unit:       trst
-  bid_unit:       ltc
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       804
-  enabled:        true
-
-- id:             trstdash
-  ask_unit:       trst
-  bid_unit:       dash
-  ask_fee:        0.0015
-  bid_fee:        0.0015
-  min_ask_price:  0.0
-  max_bid_price:  0.0
-  min_ask_amount: 0.0
-  min_bid_amount: 0.0
-  ask_precision:  4
-  bid_precision:  4
-  position:       805
-  enabled:        true
-
 - id:             trsteth
   ask_unit:       trst
   bid_unit:       eth
@@ -782,7 +241,7 @@
   min_bid_amount: 0.0
   ask_precision:  4
   bid_precision:  4
-  position:       806
+  position:       706
   enabled:        true
 
 <% end %> 

--- a/spec/controllers/admin/markets_controller_spec.rb
+++ b/spec/controllers/admin/markets_controller_spec.rb
@@ -45,7 +45,7 @@ describe Admin::MarketsController, type: :controller do
       { bid_unit:       'btc',
         bid_fee:        '0.002'.to_d,
         bid_precision:  7,
-        ask_unit:       'xrp',
+        ask_unit:       'dash',
         ask_fee:        '0.05'.to_d,
         min_ask_amount: '0.02'.to_d,
         min_bid_amount: '0.02'.to_d,

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -70,6 +70,16 @@ describe Market do
         position:      100 }
     end
 
+    let(:mirror_attributes) do
+      { ask_unit:      :usd,
+        bid_unit:      :btc,
+        bid_fee:       0.1,
+        ask_fee:       0.2,
+        ask_precision: 4,
+        bid_precision: 4,
+        position:      100 }
+    end
+
     let(:disabled_currency) { Currency.find_by_id(:eur) }
 
     it 'creates valid record' do
@@ -85,6 +95,12 @@ describe Market do
 
     it 'validates uniqueness of ID' do
       record = build(:market, :btcusd)
+      record.save
+      expect(record.errors.full_messages).to include(/id has already been taken/i)
+    end
+
+    it 'validates mirror market pair' do
+      record = Market.new(mirror_attributes)
       record.save
       expect(record.errors.full_messages).to include(/id has already been taken/i)
     end


### PR DESCRIPTION
- Add validation for prevent user to create mirror market pairs;
- Change market seed template (delete mirror pairs and change `ask/bid_precision` for pairs with fiat);
closes #2068 