### PR TITLE
Sort orders by updated_at column

### DIFF
--- a/app/api/v2/entities/order.rb
+++ b/app/api/v2/entities/order.rb
@@ -78,6 +78,15 @@ module API
         )
 
         expose(
+          :updated_at,
+          format_with: :iso8601,
+          documentation: {
+            type: String,
+            desc: "Order updated time in iso8601 format."
+          }
+        )
+
+        expose(
           :origin_volume,
           as: :volume,
           documentation: {

--- a/app/api/v2/market/orders.rb
+++ b/app/api/v2/market/orders.rb
@@ -19,7 +19,7 @@ module API
           optional :order_by, type: String, values: %w(asc desc), default: 'desc', desc: 'If set, returned orders will be sorted in specific order, default to "desc".'
         end
         get '/orders' do
-          current_user.orders.order(order_param)
+          current_user.orders.order(updated_at: params[:order_by])
                       .tap { |q| q.where!(market: params[:market]) if params[:market] }
                       .tap { |q| q.where!(state: params[:state]) if params[:state] }
                       .tap { |q| present paginate(q), with: API::V2::Entities::Order }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -163,7 +163,7 @@ class Order < ActiveRecord::Base
 end
 
 # == Schema Information
-# Schema version: 20180813105100
+# Schema version: 20190213104708
 #
 # Table name: orders
 #
@@ -194,4 +194,5 @@ end
 #  index_orders_on_type_and_member_id            (type,member_id)
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
+#  index_orders_on_updated_at                    (updated_at)
 #

--- a/app/models/order_ask.rb
+++ b/app/models/order_ask.rb
@@ -53,7 +53,7 @@ class OrderAsk < Order
 end
 
 # == Schema Information
-# Schema version: 20180813105100
+# Schema version: 20190213104708
 #
 # Table name: orders
 #
@@ -84,4 +84,5 @@ end
 #  index_orders_on_type_and_member_id            (type,member_id)
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
+#  index_orders_on_updated_at                    (updated_at)
 #

--- a/app/models/order_bid.rb
+++ b/app/models/order_bid.rb
@@ -55,7 +55,7 @@ class OrderBid < Order
 end
 
 # == Schema Information
-# Schema version: 20180813105100
+# Schema version: 20190213104708
 #
 # Table name: orders
 #
@@ -86,4 +86,5 @@ end
 #  index_orders_on_type_and_member_id            (type,member_id)
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
+#  index_orders_on_updated_at                    (updated_at)
 #

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -151,7 +151,7 @@ class Trade < ActiveRecord::Base
 end
 
 # == Schema Information
-# Schema version: 20180813105100
+# Schema version: 20190213104708
 #
 # Table name: trades
 #
@@ -173,5 +173,6 @@ end
 #  index_trades_on_ask_id                           (ask_id)
 #  index_trades_on_ask_member_id_and_bid_member_id  (ask_member_id,bid_member_id)
 #  index_trades_on_bid_id                           (bid_id)
+#  index_trades_on_created_at                       (created_at)
 #  index_trades_on_market_id_and_created_at         (market_id,created_at)
 #

--- a/db/migrate/20190213104708_add_missing_indexes_to_order_and_trade.rb
+++ b/db/migrate/20190213104708_add_missing_indexes_to_order_and_trade.rb
@@ -1,0 +1,9 @@
+class AddMissingIndexesToOrderAndTrade < ActiveRecord::Migration
+  def change
+    # index_trade_on_created_at is used in Trade #h24
+    add_index :trades, :created_at unless index_exists?(:trades, :created_at)
+
+    # index_orders_on_updated_at is used in API::V2::Market::Orders
+    add_index :orders, :updated_at unless index_exists?(:orders, :updated_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190116140939) do
+ActiveRecord::Schema.define(version: 20190213104708) do
 
   create_table "accounts", force: :cascade do |t|
     t.integer  "member_id",   limit: 4,                                          null: false
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 20190116140939) do
   add_index "orders", ["type", "member_id"], name: "index_orders_on_type_and_member_id", using: :btree
   add_index "orders", ["type", "state", "market_id"], name: "index_orders_on_type_and_state_and_market_id", using: :btree
   add_index "orders", ["type", "state", "member_id"], name: "index_orders_on_type_and_state_and_member_id", using: :btree
+  add_index "orders", ["updated_at"], name: "index_orders_on_updated_at", using: :btree
 
   create_table "payment_addresses", force: :cascade do |t|
     t.string   "currency_id", limit: 10,                  null: false
@@ -258,6 +259,7 @@ ActiveRecord::Schema.define(version: 20190116140939) do
   add_index "trades", ["ask_id"], name: "index_trades_on_ask_id", using: :btree
   add_index "trades", ["ask_member_id", "bid_member_id"], name: "index_trades_on_ask_member_id_and_bid_member_id", using: :btree
   add_index "trades", ["bid_id"], name: "index_trades_on_bid_id", using: :btree
+  add_index "trades", ["created_at"], name: "index_trades_on_created_at", using: :btree
   add_index "trades", ["market_id", "created_at"], name: "index_trades_on_market_id_and_created_at", using: :btree
 
   create_table "transfers", force: :cascade do |t|


### PR DESCRIPTION
*  Orders by updated_at instead of id in API::V2::Market::Orders
* Add index_trade_on_created_at and index_orders_on_updated_at
* Expose order updated_at
* Update /api/v2/market/orders specs

closes #2060