### PR TITLE
Rename entities fields for order and expose taker_type instead of maker_type

### DIFF
--- a/app/api/v2/entities/order.rb
+++ b/app/api/v2/entities/order.rb
@@ -88,7 +88,6 @@ module API
 
         expose(
           :origin_volume,
-          as: :volume,
           documentation: {
             type: BigDecimal,
             desc: "The amount user want to sell/buy."\

--- a/app/api/v2/entities/trade.rb
+++ b/app/api/v2/entities/trade.rb
@@ -56,13 +56,13 @@ module API
         )
 
         expose(
-          :maker_type,
+          :taker_type,
           documentation: {
             type: String,
             desc: 'Trade maker order type (sell or buy).'
           }
         ) do |trade, _options|
-            trade.ask_id < trade.bid_id ? :sell : :buy
+            trade.ask_id > trade.bid_id ? :sell : :buy
         end
 
         expose(

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -59,14 +59,14 @@ class Order < ActiveRecord::Base
     return if ord_type != 'limit'
 
     Member.trigger_pusher_event member_id, :order, \
-      id:            id,
-      at:            at,
-      market:        market_id,
-      kind:          kind,
-      price:         price&.to_s('F'),
-      state:         state,
-      volume:        volume.to_s('F'),
-      origin_volume: origin_volume.to_s('F')
+      id:               id,
+      at:               at,
+      market:           market_id,
+      kind:             kind,
+      price:            price&.to_s('F'),
+      state:            state,
+      remaining_volume: volume.to_s('F'),
+      origin_volume:    origin_volume.to_s('F')
   end
 
   def kind

--- a/docs/api/websocket_api.md
+++ b/docs/api/websocket_api.md
@@ -181,16 +181,16 @@ Here is structure of `global.tickers` event expose as array with all markets pai
 
 Here is structure of `Order` event:
 
-| Field           | Description                                                  |
-| --------------- | ------------------------------------------------------------ |
-| `id`            | Unique order id.                                             |
-| `kind`          | Type of order, either `bid` or `ask`.                        |
-| `price`         | Price for each unit.                                         |
-| `state`         | One of `wait`, `done`, or `cancel`.                          |
-| `market`        | The market in which the order is placed. (In peatio `market_id`) |
-| `at`            | Order create time. (In peatio `created_at`)                  |
-| `origin_volume` | The amount user want to sell/buy.                            |
-| `volume`        | Remaining amount user want to sell/buy.                      |
+| Field              | Description                                                  |
+| ------------------ | ------------------------------------------------------------ |
+| `id`               | Unique order id.                                             |
+| `kind`             | Type of order, either `bid` or `ask`.                        |
+| `price`            | Price for each unit.                                         |
+| `state`            | One of `wait`, `done`, or `cancel`.                          |
+| `market`           | The market in which the order is placed. (In peatio `market_id`) |
+| `at`               | Order create time. (In peatio `created_at`)                  |
+| `origin_volume`    | The amount user want to sell/buy.                            |
+| `remaining_volume` | Remaining amount user want to sell/buy.                      |
 
 #### Trade
 

--- a/spec/api/v2/entities/order_spec.rb
+++ b/spec/api/v2/entities/order_spec.rb
@@ -20,7 +20,7 @@ describe API::V2::Entities::Order do
     it { expect(subject.price).to eq order.price }
     it { expect(subject.avg_price).to eq ::Trade::ZERO }
 
-    it { expect(subject.volume).to eq order.origin_volume }
+    it { expect(subject.origin_volume).to eq order.origin_volume }
     it { expect(subject.remaining_volume).to eq order.volume }
     it { expect(subject.executed_volume).to eq(order.origin_volume - order.volume) }
 

--- a/spec/api/v2/entities/trade_spec.rb
+++ b/spec/api/v2/entities/trade_spec.rb
@@ -22,7 +22,7 @@ describe API::V2::Entities::Trade do
   it { expect(subject.created_at).to eq trade.created_at.iso8601 }
 
   context 'sell order maker' do
-    it { expect(subject.maker_type).to eq :sell }
+    it { expect(subject.taker_type).to eq :buy }
   end
 
   context 'buy order maker' do
@@ -30,7 +30,7 @@ describe API::V2::Entities::Trade do
       create :trade, :btcusd, bid: create(:order_bid, :btcusd), ask: create(:order_ask, :btcusd)
     end
 
-    it { expect(subject.maker_type).to eq :buy }
+    it { expect(subject.taker_type).to eq :sell }
   end
 
   context 'empty side' do


### PR DESCRIPTION
- return in API entities and websocket api order `volume` as `remaining_volume`;
- remove alias for `origin_volume`;
- expose `taker_type` in trade entities;