### PR TITLE
Change health checks request types for k8s

### DIFF
--- a/app/api/v2/public/tools.rb
+++ b/app/api/v2/public/tools.rb
@@ -24,12 +24,12 @@ module API
 
         resource :health do
           desc 'Get application liveness status'
-          head "/alive" do
+          get "/alive" do
             status Services::HealthChecker.alive? ? 200 : 503
           end
 
           desc 'Get application readiness status'
-          head "/ready" do
+          get "/ready" do
             status Services::HealthChecker.ready? ? 200 : 503
           end
         end

--- a/spec/api/v2/public/tools_spec.rb
+++ b/spec/api/v2/public/tools_spec.rb
@@ -13,26 +13,26 @@ describe API::V2::Public::Tools, type: :request do
 
   describe '/health' do
     it 'returns successful liveness probe' do
-      head '/api/v2/public/health/alive'
+      get '/api/v2/public/health/alive'
       expect(response).to be_success
     end
 
     it 'returns failed liveness probe' do
       Market.stubs(:connected?).returns(false)
 
-      head '/api/v2/public/health/alive'
+      get '/api/v2/public/health/alive'
       expect(response).to have_http_status(503)
     end
 
     it 'returns successful readiness probe' do
-      head '/api/v2/public/health/ready'
+      get '/api/v2/public/health/ready'
       expect(response).to be_success
     end
 
     it 'returns failed readiness probe' do
       Bunny.stubs(:run).returns(false)
 
-      head '/api/v2/public/health/alive'
+      get '/api/v2/public/health/alive'
       expect(response).to have_http_status(503)
     end
   end


### PR DESCRIPTION
Change liveness/readiness probes request types to GET from HEAD.
Closes #2085.