### PR TITLE
Fix reject withdraw #2084

### DIFF
--- a/app/models/withdraw.rb
+++ b/app/models/withdraw.rb
@@ -79,7 +79,8 @@ class Withdraw < ActiveRecord::Base
     end
 
     event :reject do
-      transitions from: %i[submitted accepted confirming], to: :rejected
+      transitions from: %i[submitted accepted confirming], to: :rejected, guard: :fiat?
+      transitions from: %i[submitted accepted], to: :rejected, guard: :coin?
       after do
         unlock_funds
         record_cancel_operations!


### PR DESCRIPTION
This fixes the issue with #2084 
If the currency is crypto `confirming` status means that the transaction has appeared in blockchain and there's no way back, so it should not be rejected.

The changes are in withdraw model, it checks if the currency is fiat, if the currency is fiat then it should allow being rejected even if the status is confirming.