### PR TITLE
Limit number of returned data from ranger `global.update`

### DIFF
--- a/lib/daemons/global_state.rb
+++ b/lib/daemons/global_state.rb
@@ -16,8 +16,8 @@ while $running
     state = Global[market.id]
 
     Peatio::MQ::Events.publish("public", market.id, "update", {
-      asks: state.asks,
-      bids: state.bids,
+      asks: state.asks[0,300],
+      bids: state.bids[0,300],
     })
 
     tickers[market.id] = market.unit_info.merge(state.ticker)


### PR DESCRIPTION
closes #2148 