### PR TITLE
Remove legacy withdraw factories

### DIFF
--- a/spec/api/v2/account/balances_spec.rb
+++ b/spec/api/v2/account/balances_spec.rb
@@ -5,7 +5,7 @@ describe API::V2::Account::Balances, type: :request do
   let(:member) { create(:member, :level_3) }
   let(:deposit_btc) { create(:deposit, :deposit_btc, member: member, amount: 10) }
   let(:deposit_eth) { create(:deposit, :deposit_eth, member: member, amount: 30.5) }
-  let(:withdraw) { create(:new_btc_withdraw, member: member, sum: 5) }
+  let(:withdraw) { create(:btc_withdraw, member: member, sum: 5) }
   let(:token) { jwt_for(member) }
 
   let(:response_body) { { 'currency' => 'eth', 'balance' => '30.5', 'locked' => '0.0' } }

--- a/spec/api/v2/account/withdraws_spec.rb
+++ b/spec/api/v2/account/withdraws_spec.rb
@@ -8,7 +8,7 @@ describe API::V2::Account::Withdraws, type: :request do
   let(:level_0_member_token) { jwt_for(level_0_member) }
 
   describe 'GET /api/v2/account/withdraws' do
-    let!(:btc_withdraws) { create_list(:btc_withdraw, 20, member: member) }
+    let!(:btc_withdraws) { create_list(:btc_withdraw, 20, :with_deposit_liability, member: member) }
     let!(:usd_withdraws) { create_list(:usd_withdraw, 20, member: member) }
 
     it 'requires authentication' do

--- a/spec/api/v2/account/withdraws_spec.rb
+++ b/spec/api/v2/account/withdraws_spec.rb
@@ -9,7 +9,7 @@ describe API::V2::Account::Withdraws, type: :request do
 
   describe 'GET /api/v2/account/withdraws' do
     let!(:btc_withdraws) { create_list(:btc_withdraw, 20, :with_deposit_liability, member: member) }
-    let!(:usd_withdraws) { create_list(:usd_withdraw, 20, member: member) }
+    let!(:usd_withdraws) { create_list(:usd_withdraw, 20, :with_deposit_liability, member: member) }
 
     it 'requires authentication' do
       get '/api/v2/account/withdraws'

--- a/spec/api/v2/management/entities/withdraw_spec.rb
+++ b/spec/api/v2/management/entities/withdraw_spec.rb
@@ -24,7 +24,7 @@ describe API::V2::Management::Entities::Withdraw do
   context 'coin' do
     let(:rid) { Faker::Blockchain::Bitcoin.address }
     let(:member) { create(:member, :barong) }
-    let(:record) { create(:btc_withdraw, member: member, rid: rid) }
+    let(:record) { create(:btc_withdraw, :with_deposit_liability, member: member, rid: rid) }
 
     subject { OpenStruct.new API::V2::Management::Entities::Withdraw.represent(record).serializable_hash }
 

--- a/spec/api/v2/management/entities/withdraw_spec.rb
+++ b/spec/api/v2/management/entities/withdraw_spec.rb
@@ -5,7 +5,7 @@ describe API::V2::Management::Entities::Withdraw do
   context 'fiat' do
     let(:rid) { Faker::Bank.iban }
     let(:member) { create(:member, :barong) }
-    let(:record) { create(:usd_withdraw, member: member, rid: rid) }
+    let(:record) { create(:usd_withdraw, :with_deposit_liability, member: member, rid: rid) }
 
     subject { OpenStruct.new API::V2::Management::Entities::Withdraw.represent(record).serializable_hash }
 

--- a/spec/api/v2/management/withdraws_spec.rb
+++ b/spec/api/v2/management/withdraws_spec.rb
@@ -23,7 +23,7 @@ describe API::V2::Management::Withdraws, type: :request do
     before do
       Withdraw::STATES.tap do |states|
         (states.count * 2).times do
-          create(:btc_withdraw, member: members.sample, aasm_state: states.sample, rid: Faker::Blockchain::Bitcoin.address)
+          create(:btc_withdraw, :with_deposit_liability, member: members.sample, aasm_state: states.sample, rid: Faker::Blockchain::Bitcoin.address)
           create(:usd_withdraw, member: members.sample, aasm_state: states.sample, rid: Faker::Bank.iban)
         end
       end
@@ -177,7 +177,7 @@ describe API::V2::Management::Withdraws, type: :request do
 
     let(:signers) { %i[alex jeff] }
     let(:data) { { tid: record.tid } }
-    let(:record) { create(:btc_withdraw, member: member) }
+    let(:record) { create(:btc_withdraw, :with_deposit_liability, member: member) }
     let(:member) { create(:member, :barong) }
 
     it 'returns withdraw by TID' do

--- a/spec/api/v2/management/withdraws_spec.rb
+++ b/spec/api/v2/management/withdraws_spec.rb
@@ -24,7 +24,7 @@ describe API::V2::Management::Withdraws, type: :request do
       Withdraw::STATES.tap do |states|
         (states.count * 2).times do
           create(:btc_withdraw, :with_deposit_liability, member: members.sample, aasm_state: states.sample, rid: Faker::Blockchain::Bitcoin.address)
-          create(:usd_withdraw, member: members.sample, aasm_state: states.sample, rid: Faker::Bank.iban)
+          create(:usd_withdraw, :with_deposit_liability, member: members.sample, aasm_state: states.sample, rid: Faker::Bank.iban)
         end
       end
     end

--- a/spec/factories/withdraw.rb
+++ b/spec/factories/withdraw.rb
@@ -11,21 +11,6 @@
 # TODO: Use new withdraw factories.
 # TODO: Get rid of legacy withdraw factories.
 FactoryBot.define do
-  factory :legacy_btc_withdraw, aliases: %i[btc_withdraw], class: Withdraws::Coin do
-    currency { Currency.find(:btc) }
-    member { create(:member, :level_3) }
-    rid { Faker::Blockchain::Bitcoin.address }
-    sum { 10.to_d }
-    type { 'Withdraws::Coin' }
-
-    account do
-      member.get_account(:btc).tap do |a|
-        a.balance = 50
-        a.save(validate: false)
-      end
-    end
-  end
-
   factory :legacy_usd_withdraw, aliases: %i[usd_withdraw], class: Withdraws::Fiat do
     member { create(:member, :level_3) }
     currency { Currency.find(:usd) }
@@ -86,7 +71,7 @@ FactoryBot.define do
     end
   end
 
-  factory :new_btc_withdraw, class: Withdraws::Coin do
+  factory :btc_withdraw, class: Withdraws::Coin do
 
     # We need to have valid Liability-based balance to spend funds.
     trait :with_deposit_liability do

--- a/spec/factories/withdraw.rb
+++ b/spec/factories/withdraw.rb
@@ -8,54 +8,7 @@
 # You can create liability history by passing with_deposit_liability trait.
 #
 # TODO: Add new factories for all currencies.
-# TODO: Use new withdraw factories.
-# TODO: Get rid of legacy withdraw factories.
 FactoryBot.define do
-  factory :legacy_eth_withdraw, aliases: %i[eth_withdraw], class: Withdraws::Coin do
-    currency { Currency.find(:eth) }
-    member { create(:member, :level_3) }
-    rid { Faker::Blockchain::Bitcoin.address }
-    sum { 10.to_d }
-    type { 'Withdraws::Coin' }
-
-    account do
-      member.get_account(:eth).tap do |a|
-        a.balance = 50
-        a.save(validate: false)
-      end
-    end
-  end
-
-  factory :legacy_trst_withdraw, aliases: %i[trst_withdraw], class: Withdraws::Coin do
-    currency { Currency.find(:trst) }
-    member { create(:member, :level_3) }
-    rid { Faker::Blockchain::Bitcoin.address }
-    sum { 10.to_d }
-    type { 'Withdraws::Coin' }
-
-    account do
-      member.get_account(:trst).tap do |a|
-        a.balance = 50
-        a.save(validate: false)
-      end
-    end
-  end
-
-  factory :legacy_ring_withdraw, aliases: %i[ring_withdraw], class: Withdraws::Coin do
-    currency { Currency.find(:ring) }
-    member { create(:member, :level_3) }
-    rid { Faker::Blockchain::Bitcoin.address }
-    sum { 10.to_d }
-    type { 'Withdraws::Coin' }
-
-    account do
-      member.get_account(:ring).tap do |a|
-        a.balance = 50
-        a.save(validate: false)
-      end
-    end
-  end
-
   factory :btc_withdraw, class: Withdraws::Coin do
 
     # We need to have valid Liability-based balance to spend funds.

--- a/spec/factories/withdraw.rb
+++ b/spec/factories/withdraw.rb
@@ -11,21 +11,6 @@
 # TODO: Use new withdraw factories.
 # TODO: Get rid of legacy withdraw factories.
 FactoryBot.define do
-  factory :legacy_usd_withdraw, aliases: %i[usd_withdraw], class: Withdraws::Fiat do
-    member { create(:member, :level_3) }
-    currency { Currency.find(:usd) }
-    rid { Faker::Bank.iban }
-    sum { 1000.to_d }
-    type { 'Withdraws::Fiat' }
-
-    account do
-      member.get_account(:usd).tap do |a|
-        a.balance = 50_000
-        a.save(validate: false)
-      end
-    end
-  end
-
   factory :legacy_eth_withdraw, aliases: %i[eth_withdraw], class: Withdraws::Coin do
     currency { Currency.find(:eth) }
     member { create(:member, :level_3) }
@@ -88,7 +73,7 @@ FactoryBot.define do
     type { 'Withdraws::Coin' }
   end
 
-  factory :new_usd_withdraw, class: Withdraws::Fiat do
+  factory :usd_withdraw, class: Withdraws::Fiat do
 
     # We need to have valid Liability-based balance to spend funds.
     trait :with_deposit_liability do

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -4,7 +4,7 @@
 describe Withdraw do
   describe '#fix_precision' do
     it 'should round down to max precision' do
-      withdraw = create(:btc_withdraw, sum: '0.123456789')
+      withdraw = create(:btc_withdraw, :with_deposit_liability, sum: '0.123456789')
       expect(withdraw.sum).to eq('0.12345678'.to_d)
     end
   end
@@ -29,7 +29,7 @@ describe Withdraw do
 
   context 'coin withdraw' do
     describe '#audit!' do
-      subject { create(:btc_withdraw, sum: sum) }
+      subject { create(:btc_withdraw, :with_deposit_liability, sum: sum) }
       let(:sum) { 10.to_d }
       before { subject.submit! }
 
@@ -41,7 +41,7 @@ describe Withdraw do
 
       context 'internal recipient' do
         let(:payment_address) { create(:btc_payment_address) }
-        subject { create(:btc_withdraw, rid: payment_address.address) }
+        subject { create(:btc_withdraw, :with_deposit_liability, rid: payment_address.address) }
 
         around do |example|
           WebMock.disable_net_connect!
@@ -417,7 +417,7 @@ describe Withdraw do
     context :load do
       let(:txid) { 'a738cb8411e2141f3de43c5f3e7a3aabe71c099bb91d296ded84f0daf29d881c' }
 
-      subject { create(:btc_withdraw) }
+      subject { create(:btc_withdraw, :with_deposit_liability) }
 
       before { subject.submit! }
       before { subject.accept! }
@@ -437,7 +437,7 @@ describe Withdraw do
     context :load do
       let(:txid) { 'a738cb8411e2141f3de43c5f3e7a3aabe71c099bb91d296ded84f0daf29d881c' }
 
-      subject { create(:btc_withdraw) }
+      subject { create(:btc_withdraw, :with_deposit_liability) }
 
       before { subject.submit! }
       before { subject.accept! }
@@ -465,24 +465,24 @@ describe Withdraw do
     end
 
     context 'returns false if exceeds 24h withdraw limit' do
-      subject(:withdraw) { create(:btc_withdraw, sum: 2, aasm_state: 'accepted') }
+      subject(:withdraw) { create(:btc_withdraw, :with_deposit_liability, sum: 2, aasm_state: 'accepted') }
       it { expect(withdraw).to_not be_quick }
     end
 
     context 'returns false if exceeds 72h withdraw limit' do
-      subject(:withdraw) { create(:btc_withdraw, sum: 4, aasm_state: 'accepted') }
+      subject(:withdraw) { create(:btc_withdraw, :with_deposit_liability, sum: 4, aasm_state: 'accepted') }
       it { expect(withdraw).to_not be_quick }
     end
 
     context 'returns true if doesn\'t exceeds 24h withdraw limit' do
-      subject(:withdraw) { create(:btc_withdraw, sum: 0.5, aasm_state: 'accepted') }
+      subject(:withdraw) { create(:btc_withdraw, :with_deposit_liability, sum: 0.5, aasm_state: 'accepted') }
       it { expect(withdraw).to be_quick }
     end
 
     context 'returns false if exceeds 24h withdraw limit' do
-      subject(:withdraw) { create(:btc_withdraw, sum: 0.5, aasm_state: 'accepted') }
+      subject(:withdraw) { create(:btc_withdraw, :with_deposit_liability, sum: 0.5, aasm_state: 'accepted') }
       it do
-        second_withdraw = create(:btc_withdraw, member: withdraw.member, sum: 0.8, aasm_state: 'accepted')
+        second_withdraw = create(:btc_withdraw, :with_deposit_liability, member: withdraw.member, sum: 0.8, aasm_state: 'accepted')
         second_withdraw.process!
         expect(second_withdraw).to_not be_quick
       end
@@ -508,22 +508,22 @@ describe Withdraw do
   end
 
   it 'automatically generates TID if it is blank' do
-    expect(create(:btc_withdraw).tid).not_to be_blank
+    expect(create(:btc_withdraw, :with_deposit_liability).tid).not_to be_blank
   end
 
   it 'doesn\'t generate TID if it is not blank' do
-    expect(create(:btc_withdraw, tid: 'TID1234567890xyz').tid).to eq 'TID1234567890xyz'
+    expect(create(:btc_withdraw, :with_deposit_liability, tid: 'TID1234567890xyz').tid).to eq 'TID1234567890xyz'
   end
 
   it 'validates uniqueness of TID' do
-    record1 = create(:btc_withdraw)
-    record2 = build(:btc_withdraw, tid: record1.tid)
+    record1 = create(:btc_withdraw, :with_deposit_liability)
+    record2 = build(:btc_withdraw, tid: record1.tid, member: nil)
     record2.save
-    expect(record2.errors.full_messages.first).to match(/tid has already been taken/i)
+    expect(record2.errors[:tid]).to match(["has already been taken"])
   end
 
   it 'uppercases TID' do
-    record = create(:btc_withdraw)
+    record = create(:btc_withdraw, :with_deposit_liability)
     expect(record.tid).to eq record.tid.upcase
   end
 
@@ -567,8 +567,7 @@ describe Withdraw do
   end
 
   context 'validate min withdrawal sum' do
-
-    subject { build(:btc_withdraw, sum: 0.1) }
+    subject { build(:btc_withdraw, sum: 0.1, member: nil) }
 
     before do
       Currency.find('btc').update(min_withdraw_amount: 0.5.to_d)

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -11,7 +11,7 @@ describe Withdraw do
 
   context 'bank withdraw' do
     describe '#audit!' do
-      subject { create(:usd_withdraw) }
+      subject { create(:usd_withdraw, :with_deposit_liability) }
       before  { subject.submit! }
 
       it 'should accept withdraw with clean history' do
@@ -112,7 +112,7 @@ describe Withdraw do
   end
 
   context 'aasm_state' do
-    subject { create(:new_usd_withdraw, :with_deposit_liability, sum: 1000) }
+    subject { create(:usd_withdraw, :with_deposit_liability, sum: 1000) }
 
     before do
       subject.stubs(:send_withdraw_confirm_email)
@@ -490,7 +490,7 @@ describe Withdraw do
   end
 
   context 'fee is set to fixed value of 10' do
-    let(:withdraw) { create(:usd_withdraw, sum: 200) }
+    let(:withdraw) { create(:usd_withdraw, :with_deposit_liability, sum: 200) }
     before { Currency.any_instance.expects(:withdraw_fee).once.returns(10) }
     it 'computes fee' do
       expect(withdraw.fee).to eql 10.to_d
@@ -499,11 +499,11 @@ describe Withdraw do
   end
 
   context 'fee exceeds amount' do
-    let(:withdraw) { build(:usd_withdraw, sum: 200) }
+    let(:withdraw) { build(:usd_withdraw, sum: 200, member: nil) }
     before { Currency.any_instance.expects(:withdraw_fee).once.returns(200) }
     it 'fails validation' do
       expect(withdraw.save).to eq false
-      expect(withdraw.errors.full_messages).to include 'Amount must be greater than 0.0'
+      expect(withdraw.errors[:amount]).to match(["must be greater than 0.0"])
     end
   end
 

--- a/spec/trading/accounting_spec.rb
+++ b/spec/trading/accounting_spec.rb
@@ -78,7 +78,7 @@ describe 'Accounting' do
   end
 
   context 'withdraws' do
-    let(:btc_withdraw) { create(:new_btc_withdraw, sum: 1000.to_d, member: buyer ) }
+    let(:btc_withdraw) { create(:btc_withdraw, sum: 1000.to_d, member: buyer ) }
 
     before do
       btc_withdraw.submit!

--- a/spec/workers/withdraw_coin_spec.rb
+++ b/spec/workers/withdraw_coin_spec.rb
@@ -3,9 +3,9 @@
 
 describe Workers::AMQP::WithdrawCoin do
   let(:member) { create(:member, :barong) }
-  let(:withdrawal) { create(:new_btc_withdraw, :with_deposit_liability) }
+  let(:withdrawal) { create(:btc_withdraw, :with_deposit_liability) }
   let(:processing_withdrawal) do
-    create(:new_btc_withdraw, :with_deposit_liability)
+    create(:btc_withdraw, :with_deposit_liability)
       .tap(&:submit!)
       .tap(&:accept!)
       .tap(&:process!)


### PR DESCRIPTION
This is an effort to remove legacy withdraw factories and use/create the ones with liability operation for their account balances.

TODO:
- [x] Remove `:legacy_btc_withdraw`
- [x] Remove `:legacy_usd_withdraw`
- [x] Remove `:legacy_eth_withdraw`, `:legacy_trst_withdraw`, `:legacy_ring_withdraw`
