### PR TITLE
Fix Bitgo WalletService & WalletClient build_raw_transaction

### DIFF
--- a/app/services/wallet_service/bitgo.rb
+++ b/app/services/wallet_service/bitgo.rb
@@ -13,9 +13,10 @@ module WalletService
       pa = deposit.account.payment_address
 
       # This builds a transaction object, but does not sign or send it.
+      # TODO: For now we multiply amount by 0.9 we consider that fee is less than 10%.
       fee = client.build_raw_transaction(
           { address: destination_address },
-          deposit.amount
+          deposit.amount * 0.9
       )
 
       # We can't collect all funds we need to subtract txn fee.

--- a/lib/peatio/wallet_client/bitgo.rb
+++ b/lib/peatio/wallet_client/bitgo.rb
@@ -35,7 +35,7 @@ module WalletClient
     def build_raw_transaction(recipient, amount)
       rest_api(:post, '/wallet/' + urlsafe_wallet_id + '/tx/build', {
           recipients: [{address: normalize_address(recipient.fetch(:address)), amount: convert_to_base_unit!(amount).to_s }]
-      }.compact, false).fetch('feeInfo').fetch('fee').yield_self(&method(:convert_from_base_unit))
+      }.compact).fetch('feeInfo').fetch('fee').yield_self(&method(:convert_from_base_unit))
     end
 
     def inspect_address!(address)

--- a/spec/services/wallet_service/bitgo_spec.rb
+++ b/spec/services/wallet_service/bitgo_spec.rb
@@ -71,7 +71,7 @@ describe WalletService::Bitgo do
     let(:options) { {} }
     let(:request_method) { :post }
     let(:request_path) { '/tbtc/wallet/' + deposit_wallet.bitgo_wallet_id + '/tx/build' }
-    let(:request_body) {{recipients:[{address: hot_wallet.address, amount: "#{wallet_client.convert_to_base_unit!(deposit.amount)}" }]} }
+    let(:request_body) {{recipients:[{address: hot_wallet.address, amount: "#{wallet_client.convert_to_base_unit!(deposit.amount * 0.9)}" }]} }
     let(:response_body) {'{"feeInfo": {"fee": 3037}}'}
 
     let(:set_tx_request_path) { '/tbtc/wallet/' + deposit_wallet.bitgo_wallet_id + '/sendcoins' }


### PR DESCRIPTION
* Raise Faraday::Error in Bitgo build_raw_transaction
* Multiply deposit amount by 0.9 for successful build_raw_transaction