### PR TITLE
Advanced orders API integration

### DIFF
--- a/app/api/v2/market/orders.rb
+++ b/app/api/v2/market/orders.rb
@@ -62,8 +62,21 @@ module API
           present order, with: API::V2::Entities::Order, type: :full
         end
 
-        desc 'Create a Sell/Buy order.',
+        desc 'Legacy create a Sell/Buy order.',
           success: API::V2::Entities::Order
+        params do
+          use :market, :order
+        end
+        post '/orders/legacy' do
+          if params[:ord_type] == 'market' && params.key?(:price)
+            error!({ errors: ['market.order.market_order_price'] }, 422)
+          end
+          order = create_order(params)
+          present order, with: API::V2::Entities::Order
+        end
+
+        desc 'New Sell/Buy order API with advanced order types support.',
+             success: API::V2::Entities::Order
         params do
           use :market, :order
         end
@@ -71,7 +84,7 @@ module API
           if params[:ord_type] == 'market' && params.key?(:price)
             error!({ errors: ['market.order.market_order_price'] }, 422)
           end
-          order = create_order(params)
+          order = create_order2(params)
           present order, with: API::V2::Entities::Order
         end
 


### PR DESCRIPTION
### TODO:

# Triggers
- [x] New Order:TYPES.
- [ ] Add new parameter trigger_price (temporary) to API.
- [ ] In #create_order use old source in case of primitive order(limit market) or create_advanced.
- [ ] Inside create_advanced_order
       * In single SQL tx create order and trigger.
       * Publish message to 
```ruby
        AMQPQueue.enqueue(:events_processor,
                            subject: :submit_order,
                            payload: trigger.as_json_for_events_processor)
```
- [ ] Return Order to user
- [ ] Add some specs
- [ ] Kee legacy API which uses old code without changes (just for testing purpose because it's considered to be stable)

- [ ] New Order state (if needed).

