### PR TITLE
Retry withdraw on failure

### DIFF
--- a/app/models/withdraws/coin.rb
+++ b/app/models/withdraws/coin.rb
@@ -50,7 +50,7 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190402130148
+# Schema version: 20190617090551
 #
 # Table name: withdraws
 #
@@ -62,6 +62,7 @@ end
 #  fee          :decimal(32, 16)  not null
 #  txid         :string(128)
 #  aasm_state   :string(30)       not null
+#  attempts     :integer          default(0), not null
 #  block_number :integer
 #  sum          :decimal(32, 16)  not null
 #  type         :string(30)       not null

--- a/app/models/withdraws/fiat.rb
+++ b/app/models/withdraws/fiat.rb
@@ -8,7 +8,7 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190402130148
+# Schema version: 20190617090551
 #
 # Table name: withdraws
 #
@@ -20,6 +20,7 @@ end
 #  fee          :decimal(32, 16)  not null
 #  txid         :string(128)
 #  aasm_state   :string(30)       not null
+#  attempts     :integer          default(0), not null
 #  block_number :integer
 #  sum          :decimal(32, 16)  not null
 #  type         :string(30)       not null

--- a/app/workers/worker/withdraw_coin.rb
+++ b/app/workers/worker/withdraw_coin.rb
@@ -68,7 +68,11 @@ module Worker
           report_exception(e)
           Rails.logger.warn { "Setting withdraw state to failed." }
         ensure
-          withdraw.fail!
+          if withdraw.may_retry?
+            withdraw.retry!
+          else
+            withdraw.fail!
+          end
           Rails.logger.warn { "OK." }
         end
       end

--- a/app/workers/worker/withdraw_coin.rb
+++ b/app/workers/worker/withdraw_coin.rb
@@ -68,8 +68,8 @@ module Worker
           report_exception(e)
           Rails.logger.warn { "Setting withdraw state to failed." }
         ensure
-          if withdraw.may_retry?
-            withdraw.retry!
+          if withdraw.may_process?
+            withdraw.process!
           else
             withdraw.fail!
           end

--- a/db/migrate/20190617090551_add_retries_to_withdraw.rb
+++ b/db/migrate/20190617090551_add_retries_to_withdraw.rb
@@ -1,0 +1,5 @@
+class AddRetriesToWithdraw < ActiveRecord::Migration[5.2]
+  def change
+    add_column :withdraws, :attempts, :integer, default: 0, null: false, after: :aasm_state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_142209) do
+ActiveRecord::Schema.define(version: 2019_06_17_090551) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "member_id", null: false
@@ -300,6 +300,7 @@ ActiveRecord::Schema.define(version: 2019_05_29_142209) do
     t.decimal "fee", precision: 32, scale: 16, null: false
     t.string "txid", limit: 128, collation: "utf8_bin"
     t.string "aasm_state", limit: 30, null: false
+    t.integer "attempts", default: 0, null: false
     t.integer "block_number"
     t.decimal "sum", precision: 32, scale: 16, null: false
     t.string "type", limit: 30, null: false

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -440,18 +440,18 @@ describe Withdraw do
         subject.process!
       end
 
-      it 'transitions to :failing after calling #retry from :processing' do
+      it 'transitions to :processing after calling #process from :processing' do
         subject.expects(:send_coins!)
 
-        expect { subject.retry! }.to_not change { subject.account.amount }
+        expect { subject.process! }.to_not change { subject.account.amount }
         expect(subject.failing?).to be true
       end
 
-      it 'transitions to :failing after calling #retry from :confirming' do
+      it 'transitions to :processing after calling #process from :confirming' do
         subject.dispatch!
         subject.expects(:send_coins!)
 
-        expect { subject.retry! }.to_not change { subject.account.amount }
+        expect { subject.process! }.to_not change { subject.account.amount }
         expect(subject.failing?).to be true
       end
     end
@@ -461,11 +461,11 @@ describe Withdraw do
         subject.submit!
         subject.accept!
         subject.process!
-        Withdraw::MAX_ATTEMPTS.times { subject.retry! }
+        Withdraw::MAX_ATTEMPTS.times { subject.process! }
       end
 
       it 'transitions to :failed after calling #fail from :failing' do
-        expect(subject.may_retry?).to be false
+        expect(subject.may_process?).to be false
         expect { subject.fail! }.to_not change { subject.account.amount }
         expect(subject.failed?).to be true
       end

--- a/spec/workers/withdraw_coin_spec.rb
+++ b/spec/workers/withdraw_coin_spec.rb
@@ -64,9 +64,9 @@ describe Worker::WithdrawCoin do
         .raises(Peatio::Wallet::Registry::NotRegisteredAdapterError)
     end
 
-    it 'returns true and fail withdrawal' do
+    it 'returns true and marks withdrawal as failing' do
       expect(Worker::WithdrawCoin.new.process(processing_withdrawal.as_json)).to be_truthy
-      expect(processing_withdrawal.reload.failed?).to be_truthy
+      expect(processing_withdrawal.reload.failing?).to be_truthy
     end
   end
 
@@ -95,9 +95,9 @@ describe Worker::WithdrawCoin do
                     .raises(Peatio::Blockchain::ClientError)
     end
 
-    it 'returns true and fail withdrawal' do
+    it 'returns true and marks withdrawal as failing' do
       expect(Worker::WithdrawCoin.new.process(processing_withdrawal.as_json)).to be_truthy
-      expect(processing_withdrawal.reload.failed?).to be_truthy
+      expect(processing_withdrawal.reload.failing?).to be_truthy
     end
   end
 

--- a/spec/workers/withdraw_coin_spec.rb
+++ b/spec/workers/withdraw_coin_spec.rb
@@ -64,9 +64,10 @@ describe Worker::WithdrawCoin do
         .raises(Peatio::Wallet::Registry::NotRegisteredAdapterError)
     end
 
-    it 'returns true and marks withdrawal as failing' do
+    it 'returns true and marks withdrawal as failed' do
+      processing_withdrawal.update!(attempts: 5)
       expect(Worker::WithdrawCoin.new.process(processing_withdrawal.as_json)).to be_truthy
-      expect(processing_withdrawal.reload.failing?).to be_truthy
+      expect(processing_withdrawal.reload.failed?).to be_truthy
     end
   end
 
@@ -93,11 +94,13 @@ describe Worker::WithdrawCoin do
                     .expects(:build_withdrawal!)
                     .with(instance_of(Withdraws::Coin))
                     .raises(Peatio::Blockchain::ClientError)
+      Withdraw.any_instance.stubs(:attempts).returns(5)
     end
 
-    it 'returns true and marks withdrawal as failing' do
+    it 'returns true and marks withdrawal as failed' do
+      processing_withdrawal.update!(attempts: 5)
       expect(Worker::WithdrawCoin.new.process(processing_withdrawal.as_json)).to be_truthy
-      expect(processing_withdrawal.reload.failing?).to be_truthy
+      expect(processing_withdrawal.reload.failed?).to be_truthy
     end
   end
 


### PR DESCRIPTION
Here is overview of general idea:

In case of failure withdraw changes state to `failing` and re-queue  withdraw request.
After 5 attempts it goes to `failed` state. 