### PR TITLE
Update admin API

### DIFF
--- a/app/api/v2/admin/blockchain_params.rb
+++ b/app/api/v2/admin/blockchain_params.rb
@@ -10,81 +10,81 @@ module API
         params :create_blockchain_params do
           requires :key,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:key][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:key][:desc] }
           requires :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:name][:desc] }
           requires :client,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:client][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:client][:desc] }
           requires :server,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:server][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:server][:desc] }
           requires :height,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_height' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_height' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:height][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:height][:desc] }
           requires :explorer_transaction,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:explorer_transaction][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:explorer_transaction][:desc] }
           requires :explorer_address,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:explorer_address][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:explorer_address][:desc] }
           optional :status,
                    type: String,
                    values: { value: %w(active disabled), message: 'admin.blockchain.invalid_status' },
                    default: 'active',
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:status][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:status][:desc] }
           optional :min_confirmations,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_min_confirmations' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_min_confirmations' },
                    default: 6,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:min_confirmations][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:min_confirmations][:desc] }
           optional :step,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_step' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_step' },
                    default: 6,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:step][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:step][:desc] }
         end
 
         params :update_blockchain_params do
           requires :id,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_id' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:id][:desc] }
           optional :key,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:key][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:key][:desc] }
           optional :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:name][:desc] }
           optional :client,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:client][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:client][:desc] }
           optional :server,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:server][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:server][:desc] }
           optional :height,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_height' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_height' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:height][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:height][:desc] }
           optional :explorer_transaction,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:explorer_transaction][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:explorer_transaction][:desc] }
           optional :explorer_address,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:explorer_address][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:explorer_address][:desc] }
           optional :status,
                    type: String,
                    values: { value: %w(active disabled), message: 'admin.blockchain.invalid_status' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:status][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:status][:desc] }
           optional :min_confirmations,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_min_confirmations' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_min_confirmations' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:min_confirmations][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:min_confirmations][:desc] }
           optional :step,
                    type: { value: Integer, message: 'admin.blockchain.non_integer_step' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.blockchain.non_positive_step' },
-                   desc: -> { V2::Admin::Entities::Blockchain.documentation[:step][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Blockchain.documentation[:step][:desc] }
         end
       end
     end

--- a/app/api/v2/admin/currency_params.rb
+++ b/app/api/v2/admin/currency_params.rb
@@ -10,145 +10,145 @@ module API
         params :create_currency_params do
           requires :id,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:id][:desc] }
           requires :symbol,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:symbol][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:symbol][:desc] }
           optional :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:name][:desc] }
           optional :type,
                    type: String,
                    values: { value: ::Currency.types.map(&:to_s), message: 'admin.currency.invalid_type' },
                    default: 'coin',
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:type][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:type][:desc] }
           given type: ->(val) { val == 'coin' } do
             requires :blockchain_key,
                      type: String,
                      values: { value: -> { ::Blockchain.pluck(:key) }, message: 'admin.currency.blockchain_key_doesnt_exist' },
-                     desc: -> { V2::Admin::Entities::Currency.documentation[:blockchain_key][:desc] }
+                     desc: -> { API::V2::Admin::Entities::Currency.documentation[:blockchain_key][:desc] }
           end
           optional :deposit_fee,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_deposit_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_deposit_fee' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
           optional :min_deposit_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_deposit_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_deposit_fee' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
           optional :min_collection_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_min_collection_amount' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_min_collection_amount' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:min_collection_amount][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:min_collection_amount][:desc] }
           optional :withdraw_fee,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_fee' },
                    values: { value: -> (p){ p >= 0  }, message: 'admin.currency.ivalid_withdraw_fee' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_fee][:desc] }
           optional :min_withdraw_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_min_withdraw_amount' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_min_withdraw_amount' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:min_withdraw_amount][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:min_withdraw_amount][:desc] }
           optional :withdraw_limit_24h,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_limit_24h' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_withdraw_limit_24h' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_limit_24h][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_limit_24h][:desc] }
           optional :withdraw_limit_72h,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_limit_72h' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_withdraw_limit_72h' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_limit_72h][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_limit_72h][:desc] }
           optional :position,
                    type: { value: Integer, message: 'admin.currency.non_integer_position' },
                    default: 0,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:position][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:position][:desc] }
           optional :options,
                    type: { value: JSON, message: 'admin.currency.non_json_options' },
                    default: {},
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:options][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:options][:desc] }
           optional :enabled,
                    type: { value: Boolean, message: 'admin.currency.non_boolean_enabled' },
                    default: true,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:enabled][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:enabled][:desc] }
           optional :base_factor,
                    type: { value: Integer, message: 'admin.currency.non_integer_base_factor' },
                    default: 1,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:base_factor][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:base_factor][:desc] }
           optional :precision,
                    type: { value: Integer, message: 'admin.currency.non_integer_base_precision' },
                    default: 8,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:precision][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:precision][:desc] }
           optional :icon_url,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:icon_url][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:icon_url][:desc] }
         end
 
         params :update_currency_params do
           requires :id,
                    type: String,
                    values: { value: -> { ::Currency.ids }, message: 'admin.currency.doesnt_exist' },
-                   desc: -> { V2::Entities::Currency.documentation[:id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:id][:desc] }
           optional :symbol,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:symbol][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:symbol][:desc] }
           optional :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:name][:desc] }
           optional :blockchain_key,
                    type: String,
                    values: { value: -> { ::Blockchain.pluck(:key) }, message: 'admin.currency.blockchain_key_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:blockchain_key][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:blockchain_key][:desc] }
           optional :deposit_fee,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_deposit_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_deposit_fee' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
           optional :min_deposit_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_deposit_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_deposit_fee' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:deposit_fee][:desc] }
           optional :min_collection_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_min_collection_amount' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_min_collection_amount' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:min_collection_amount][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:min_collection_amount][:desc] }
           optional :withdraw_fee,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_fee' },
                    values: { value: -> (p){ p >= 0  }, message: 'admin.currency.invalid_withdraw_fee' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_fee][:desc] }
           optional :min_withdraw_amount,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_min_withdraw_amount' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_min_withdraw_amount' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:min_withdraw_amount][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:min_withdraw_amount][:desc] }
           optional :withdraw_limit_24h,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_limit_24h' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_withdraw_limit_24h' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_limit_24h][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_limit_24h][:desc] }
           optional :withdraw_limit_72h,
                    type: { value: BigDecimal, message: 'admin.currency.non_decimal_withdraw_limit_72h' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.currency.invalid_withdraw_limit_72h' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:withdraw_limit_72h][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:withdraw_limit_72h][:desc] }
           optional :position,
                    type: { value: Integer, message: 'admin.currency.non_integer_position' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:position][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:position][:desc] }
           optional :options,
                    type: { value: JSON, message: 'admin.currency.non_json_options' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:options][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:options][:desc] }
           optional :enabled,
                    type: { value: Boolean, message: 'admin.currency.non_boolean_enabled' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:enabled][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:enabled][:desc] }
           optional :base_factor,
                    type: { value: Integer, message: 'admin.currency.non_integer_base_factor' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:base_factor][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:base_factor][:desc] }
           optional :precision,
                    type: { value: Integer, message: 'admin.currency.non_integer_base_precision' },
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:precision][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:precision][:desc] }
           optional :icon_url,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Currency.documentation[:icon_url][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Currency.documentation[:icon_url][:desc] }
         end
       end
     end

--- a/app/api/v2/admin/deposit_params.rb
+++ b/app/api/v2/admin/deposit_params.rb
@@ -1,0 +1,113 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module DepositParams
+        extend ::Grape::API::Helpers
+
+        COIN_ACTIONS = %w(accept collect collect_fee)
+        FIAT_ACTIONS = %w(accept reject)
+
+        params :get_deposits_params do
+          optional :currency,
+                   type: String,
+                   values: { value: -> { Currency.enabled.codes(bothcase: true) }, message: 'admin.currency.doesnt_exist' },
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:currency][:desc] }
+          optional :state,
+                   type: String,
+                   values: { value: -> { Deposit::STATES.map(&:to_s) }, message: 'admin.deposit.invalid_state' },
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:state][:desc] }
+          optional :limit,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_limit' },
+                   values: { value: 1..100, message: 'admin.deposit.invalid_limit' },
+                   default: 100,
+                   desc: "Number of deposits per page (defaults to 100, maximum is 100)."
+          optional :page,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_page' },
+                   values: { value: -> (p){ p.try(:positive?) }, message: 'admin.deposit.non_positive_page'},
+                   default: 1,
+                   desc: 'Page number (defaults to 1).'
+          optional :member,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:member][:desc] }
+          optional :id,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:id][:desc] }
+          optional :txid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:blockchain_txid][:desc] }
+          optional :address,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:address][:desc] }
+          optional :tid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:tid][:desc] }
+          optional :type,
+                   type: String,
+                   values: { value: %w(fiat coin), message: 'admin.deposit.invalid_type' },
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:type][:desc] }
+          optional :amount_from,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_amount_from' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_from' },
+                   desc: 'If set, only withdraws with amount greater or equal then will be returned.'
+          optional :amount_to,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_amount_to' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_to' },
+                   desc: 'If set, only withdraws with amount less then will be returned.'
+          optional :updated_at_from,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_updated_at_from' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits updated after the time will be returned."
+          optional :updated_at_to,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_updated_at_to' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits updated before the time will be returned."
+          optional :created_at_from,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_created_at_from' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits created after the time will be returned."
+          optional :created_at_to,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_created_at_to' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits created before the time will be returned."
+          optional :done_at_from,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_done_at_from' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits done after the time will be returned."
+          optional :done_at_to,
+                   type: { value: Integer, message: 'admin.deposit.non_integer_done_at_to' },
+                   allow_blank: { value: false, message: 'admin.deposit.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only deposits done before the time will be returned."
+          optional :ordering,
+                   type: String,
+                   values: { value: %w(asc desc), message: 'admin.deposit.invalid_ordering' },
+                   default: 'asc',
+                   desc: 'If set, returned deposits will be sorted in specific order, defaults to \'asc\'.'
+          optional :order_by,
+                   default: 'id',
+                   type: String,
+                   desc: 'Name of the field to order deposits by.'
+        end
+
+        params :update_deposit_params do
+          requires :id,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Deposit.documentation[:id][:desc] }
+          requires :action,
+                   type: String,
+                   values: { value: -> { COIN_ACTIONS | FIAT_ACTIONS }, message: 'admin.deposit.invalid_action' },
+                   desc: "Action to perform on deposit. Valid actions for coin are #{COIN_ACTIONS}."\
+                         "Valid actions for fiat are #{FIAT_ACTIONS}."
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/deposits.rb
+++ b/app/api/v2/admin/deposits.rb
@@ -1,0 +1,83 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      class Deposits < Grape::API
+        helpers API::V2::Admin::DepositParams
+        helpers API::V2::Admin::ParamsHelpers
+
+        desc 'Get all deposits, result is paginated.',
+          is_array: true,
+          success: API::V2::Admin::Entities::Deposit
+        params do
+          use :get_deposits_params
+        end
+        get '/deposits' do
+          authorize! :read, Deposit
+
+          ransack_params = {
+            aasm_state_eq: params[:state],
+            member_id_eq: params[:member],
+            currency_id_eq: params[:currency],
+            id_eq: params[:id],
+            txid_eq: params[:txid],
+            tid_eq: params[:tid],
+            address_eq: params[:address],
+            amount_gteq: params[:amount_from],
+            amount_lt: params[:amount_to],
+            type_eq: params[:type].present? ? "Deposits::#{params[:type]}" : nil,
+            created_at_gteq: time_param(params[:created_at_from]),
+            created_at_lt: time_param(params[:created_at_to]),
+            updated_at_gteq: time_param(params[:updated_at_from]),
+            updated_at_lt: time_param(params[:updated_at_to]),
+            completed_at_gteq: time_param(params[:done_at_from]),
+            completed_at_lt: time_param(params[:done_at_to]),
+          }
+
+          search = Deposit.ransack(ransack_params)
+          search.sorts = "#{params[:order_by]} #{params[:ordering]}"
+
+          present paginate(search.result), with: API::V2::Admin::Entities::Deposit
+        end
+
+        desc 'Update deposit.' do
+          success API::V2::Admin::Entities::Deposit
+        end
+        params do
+          use :update_deposit_params
+        end
+        post '/deposits/update' do
+          authorize! :write, Deposit
+
+          deposit = Deposit.find(params[:id])
+          if deposit.fiat?
+            case params[:action]
+            when 'accept'
+              error!({ errors: ['admin.deposit.cannot_accept'] }, 422) unless deposit.charge!
+            when 'reject'
+              error!({ errors: ['admin.deposit.cannot_reject'] }, 422) unless deposit.reject!
+            else
+              error!({ errors: ['admin.deposit.invalid_action'] }, 422)
+            end
+          else
+            case params[:action]
+            when 'accept'
+              error!({ errors: ['admin.deposit.cannot_accept'] }, 422) unless deposit.accept!
+            when 'collect'
+              error!({ errors: ['admin.deposit.cannot_collect'] }, 422) unless deposit.may_dispatch? && deposit.collect!(false)
+            when 'collect_fee'
+              success =  deposit.may_dispatch? && deposit.currency.is_erc20? && deposit.collect!
+              error!({ errors: ['admin.deposit.cannot_collect_fee'] }, 422) unless success
+            else
+              error!({ errors: ['admin.deposit.invalid_action'] }, 422)
+            end
+          end
+
+          present deposit.reload with: API::V2::Admin::Entities::Deposit
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/entities/blockchain.rb
+++ b/app/api/v2/admin/entities/blockchain.rb
@@ -10,7 +10,7 @@ module API
             :id,
             documentation:{
               type: Integer,
-              desc: 'Unique blockchain id'
+              desc: 'Unique blockchain id.'
             }
           )
 
@@ -18,7 +18,7 @@ module API
             :key,
             documentation:{
               type: String,
-              desc: 'Unique blockchain key'
+              desc: 'Unique blockchain key.'
             }
           )
 
@@ -26,7 +26,7 @@ module API
             :name,
             documentation:{
               type: String,
-              desc: 'Unique blockchain name'
+              desc: 'Unique blockchain name.'
             }
           )
 
@@ -34,7 +34,7 @@ module API
             :client,
             documentation:{
               type: String,
-              desc: 'Unique blockchain client'
+              desc: 'Unique blockchain client.'
             }
           )
 
@@ -42,7 +42,7 @@ module API
             :server,
             documentation:{
               type: String,
-              desc: 'Blockchain server url'
+              desc: 'Blockchain server url.'
             }
           )
 
@@ -50,7 +50,7 @@ module API
             :height,
             documentation:{
               type: Integer,
-              desc: 'The number of blocks preceding a particular block on blockchain'
+              desc: 'The number of blocks preceding a particular block on blockchain.'
             }
           )
 
@@ -58,7 +58,7 @@ module API
             :step,
             documentation:{
               type: Integer,
-              desc: 'Blockchain step'
+              desc: 'Blockchain step.'
             }
           )
 
@@ -66,7 +66,7 @@ module API
             :explorer_address,
             documentation:{
               type: String,
-              desc: 'Blockchain explorer address'
+              desc: 'Blockchain explorer address.'
             }
           )
 
@@ -74,7 +74,7 @@ module API
             :explorer_transaction,
             documentation:{
               type: String,
-              desc: 'Blockchain explorer transaction'
+              desc: 'Blockchain explorer transaction.'
             }
           )
 
@@ -82,7 +82,7 @@ module API
             :min_confirmations,
             documentation:{
               type: Integer,
-              desc: 'Blockchain min confirmations'
+              desc: 'Blockchain min confirmations.'
             }
           )
 
@@ -90,7 +90,7 @@ module API
             :status,
             documentation:{
               type: String,
-              desc: 'Blockchain status (active/disabled)'
+              desc: 'Blockchain status (active/disabled).'
             }
           )
 
@@ -99,7 +99,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Blockchain created time in iso8601 format'
+              desc: 'Blockchain created time in iso8601 format.'
             }
           )
 
@@ -108,7 +108,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Blockchain updated time in iso8601 format'
+              desc: 'Blockchain updated time in iso8601 format.'
             }
           )
         end

--- a/app/api/v2/admin/entities/currency.rb
+++ b/app/api/v2/admin/entities/currency.rb
@@ -18,7 +18,7 @@ module API
               :name,
               documentation: {
                   type: String,
-                  desc: 'Currency name'
+                  desc: 'Currency name.'
               },
               if: -> (currency){ currency.name.present? }
           )
@@ -27,7 +27,7 @@ module API
             :blockchain_key,
             documentation: {
                 type: String,
-                desc: 'Currency blockchain key'
+                desc: 'Currency blockchain key.'
             },
             if: -> (currency){ currency.coin? }
           )
@@ -36,7 +36,7 @@ module API
             :symbol,
             documentation: {
               type: String,
-              desc: 'Currency symbol'
+              desc: 'Currency symbol.'
             }
           )
 
@@ -44,7 +44,7 @@ module API
             :explorer_transaction,
             documentation: {
               type: String,
-              desc: 'Currency transaction exprorer url template'
+              desc: 'Currency transaction exprorer url template.'
             },
             if: -> (currency){ currency.coin? }
           )
@@ -53,7 +53,7 @@ module API
             :explorer_address,
             documentation: {
               type: String,
-              desc: 'Currency address exprorer url template'
+              desc: 'Currency address exprorer url template.'
             },
             if: -> (currency){ currency.coin? }
           )
@@ -62,7 +62,7 @@ module API
             :type,
             documentation: {
               type: String,
-              desc: 'Currency type'
+              desc: 'Currency type.'
             }
           )
 
@@ -70,7 +70,7 @@ module API
             :deposit_fee,
             documentation: {
               type: BigDecimal,
-              desc: 'Currency deposit fee'
+              desc: 'Currency deposit fee.'
             }
           )
 
@@ -78,7 +78,7 @@ module API
             :min_deposit_amount,
             documentation: {
               type: BigDecimal,
-              desc: 'Minimal deposit amount'
+              desc: 'Minimal deposit amount.'
             }
           )
 
@@ -86,7 +86,7 @@ module API
             :withdraw_fee,
             documentation: {
               type: BigDecimal,
-              desc: 'Currency withdraw fee'
+              desc: 'Currency withdraw fee.'
             }
           )
 
@@ -94,7 +94,7 @@ module API
             :min_withdraw_amount,
             documentation: {
               type: BigDecimal,
-              desc: 'Minimal withdraw amount'
+              desc: 'Minimal withdraw amount.'
             }
           )
 
@@ -102,7 +102,7 @@ module API
             :min_collection_amount,
             documentation: {
               type: BigDecimal,
-              desc: 'Minimal collection amount'
+              desc: 'Minimal collection amount.'
             }
           )
 
@@ -110,7 +110,7 @@ module API
             :withdraw_limit_24h,
             documentation: {
               type: BigDecimal,
-              desc: 'Currency 24h withdraw limit'
+              desc: 'Currency 24h withdraw limit.'
             }
           )
 
@@ -118,7 +118,7 @@ module API
             :withdraw_limit_72h,
             documentation: {
               type: BigDecimal,
-              desc: 'Currency 72h withdraw limit'
+              desc: 'Currency 72h withdraw limit.'
             }
           )
 
@@ -126,7 +126,7 @@ module API
             :base_factor,
             documentation: {
               type: Integer,
-              desc: 'Currency base factor'
+              desc: 'Currency base factor.'
             }
           )
 
@@ -134,7 +134,7 @@ module API
             :precision,
             documentation: {
               type: Integer,
-              desc: 'Currency precision'
+              desc: 'Currency precision.'
             }
           )
 
@@ -142,7 +142,7 @@ module API
             :position,
             documentation: {
               type: Integer,
-              desc: 'Currency position'
+              desc: 'Currency position.'
             }
           )
 
@@ -150,7 +150,7 @@ module API
             :enabled,
             documentation: {
               type: String,
-              desc: 'Currency display'
+              desc: 'Currency display.'
             }
           )
 
@@ -158,7 +158,7 @@ module API
             :icon_url,
             documentation: {
               type: String,
-              desc: 'Currency icon'
+              desc: 'Currency icon.'
             },
             if: -> (currency){ currency.icon_url.present? }
           )
@@ -167,7 +167,7 @@ module API
             :options,
             documentation: {
               type: JSON,
-              desc: 'Currency options'
+              desc: 'Currency options.'
             },
             if: -> (currency){ currency.coin? }
           )
@@ -177,7 +177,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Currency created time in iso8601 format'
+              desc: 'Currency created time in iso8601 format.'
             }
           )
 
@@ -186,7 +186,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Currency updated time in iso8601 format'
+              desc: 'Currency updated time in iso8601 format.'
             }
           )
         end

--- a/app/api/v2/admin/entities/deposit.rb
+++ b/app/api/v2/admin/entities/deposit.rb
@@ -1,0 +1,172 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module Entities
+        class Deposit < Base
+          expose(
+            :id,
+            documentation: {
+              type: Integer,
+              desc: 'Unique deposit id.'
+            }
+          )
+
+          expose(
+            :currency_id,
+            as: :currency,
+            documentation: {
+              type: String,
+              desc: 'Deposit currency id.'
+            }
+          )
+
+          expose(
+            :member_id,
+            as: :member,
+            documentation: {
+              type: String,
+              desc: 'The member id.'
+            }
+          )
+
+          expose(
+            :uid,
+            documentation: {
+              type: Integer,
+              desc: 'Deposit member uid.'
+            }
+          )
+
+          expose(
+            :amount,
+            format_with: :decimal,
+            documentation: {
+              type: BigDecimal,
+              desc: 'Deposit amount.'
+            }
+          )
+
+          expose(
+            :fee,
+            documentation: {
+              type: BigDecimal,
+              desc: 'Deposit fee.'
+            }
+          )
+
+          expose(
+            :txid,
+            as: :blockchain_txid,
+            documentation: {
+              type: String,
+              desc: 'Deposit transaction id.'
+            },
+            if: ->(deposit) { deposit.coin? }
+          )
+
+          expose(
+            :confirmations,
+            documentation: {
+              type: Integer,
+              desc: 'Number of deposit confirmations.'
+            },
+            if: ->(deposit) { deposit.coin? }
+          )
+
+          expose(
+            :address,
+            documentation: {
+              type: String,
+              desc: 'Deposit blockchain address.'
+            },
+            if: ->(deposit) { deposit.coin? }
+          )
+
+          expose(
+            :txout,
+            documentation: {
+              type: Integer,
+              desc: 'Deposit blockchain transaction output.'
+            },
+            if: ->(deposit) { deposit.coin? }
+          )
+
+          expose(
+            :block_number,
+            documentation: {
+              type: Integer,
+              desc: 'Deposit blockchain block number.'
+            },
+            if: ->(deposit) { deposit.coin? }
+          )
+
+          expose(
+            :type,
+            documentation: {
+              type: String,
+              desc: 'Deposit type (fiat or coin).'
+            }
+          ) { |d| d.fiat? ? :fiat : :coin }
+
+          expose(
+            :aasm_state,
+            as: :state,
+            documentation: {
+              type: String,
+              desc: 'Deposit state.'
+            }
+          )
+
+          expose(
+            :tid,
+            documentation: {
+              type: String,
+              desc: 'Deposit tid.'
+            }
+          )
+
+          expose(
+            :spread,
+            documentation: {
+              type: String,
+              desc: 'Deposit collection spread.'
+            },
+            if: -> (deposit) { !deposit.spread.empty? }
+          )
+
+          expose(
+            :updated_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when deposit was updated.'
+            }
+          )
+
+          expose(
+            :created_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when deposit was created.'
+            }
+          )
+
+          expose(
+            :completed_at,
+            as: :done_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when deposit was completed.'
+            },
+            if: ->(deposit) { deposit.completed? }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/entities/market.rb
+++ b/app/api/v2/admin/entities/market.rb
@@ -18,18 +18,18 @@ module API
           )
 
           expose(
-            :ask_unit,
+            :base_unit,
             documentation: {
               type: String,
-              desc: 'Market ask unit'
+              desc: 'Market base(ask) unit.'
             }
           )
 
           expose(
-            :bid_unit,
+            :quote_unit,
             documentation: {
               type: String,
-              desc: 'Market bid unit'
+              desc: 'Market quote(bid) unit.'
             }
           )
 
@@ -37,7 +37,7 @@ module API
             :ask_fee,
             documentation: {
               type: BigDecimal,
-              desc: 'Market ask fee'
+              desc: 'Market ask fee.'
             }
           )
 
@@ -45,55 +45,47 @@ module API
             :bid_fee,
             documentation: {
               type: BigDecimal,
-              desc: 'Market bid fee'
+              desc: 'Market bid fee.'
             }
           )
 
           expose(
-            :min_ask_price,
+            :min_price,
             documentation: {
               type: BigDecimal,
-              desc: 'Max ask order price'
+              desc: 'Min order price.'
             }
           )
 
           expose(
-            :max_bid_price,
+            :max_price,
             documentation: {
               type: BigDecimal,
-              desc: 'Max bid order price'
+              desc: 'Max order price.'
             }
           )
 
           expose(
-            :min_ask_amount,
+            :min_amount,
             documentation: {
               type: BigDecimal,
-              desc: 'Min ask order amount'
+              desc: 'Min order amount.'
             }
           )
 
           expose(
-            :min_bid_amount,
+            :amount_precision,
             documentation: {
-              type: BigDecimal,
-              desc: 'Min bid order amount'
+              type: Integer,
+              desc: 'Amount precision.'
             }
           )
 
           expose(
-            :ask_precision,
+            :price_precision,
             documentation: {
-              type: BigDecimal,
-              desc: 'Precision for ask order'
-            }
-          )
-
-          expose(
-            :bid_precision,
-            documentation: {
-              type: BigDecimal,
-              desc: 'Precision for bid order'
+              type: Integer,
+              desc: 'Price precision.'
             }
           )
 
@@ -101,15 +93,15 @@ module API
             :position,
             documentation: {
               type: Integer,
-              desc: 'Market position'
+              desc: 'Market position.'
             }
           )
 
           expose(
-            :enabled,
+            :state,
             documentation: {
               type: String,
-              desc: 'Market display'
+              desc: "Market state, one of #{::Market::STATES}."
             }
           )
 
@@ -118,7 +110,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Market created time in iso8601 format'
+              desc: 'Market created time in iso8601 format.'
             }
           )
 
@@ -127,7 +119,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Market updated time in iso8601 format'
+              desc: 'Market updated time in iso8601 format.'
             }
           )
         end

--- a/app/api/v2/admin/entities/order.rb
+++ b/app/api/v2/admin/entities/order.rb
@@ -10,7 +10,7 @@ module API
             :id,
             documentation:{
               type: Integer,
-              desc: 'Unique order id'
+              desc: 'Unique order id.'
             }
           )
 
@@ -18,7 +18,7 @@ module API
             :side,
             documentation: {
               type: String,
-              desc: "Either 'sell' or 'buy'"
+              desc: "Either 'sell' or 'buy'."
             }
           )
 
@@ -26,7 +26,7 @@ module API
             :ord_type,
             documentation: {
               type: String,
-              desc: "Type of order, either 'limit' or 'market'"
+              desc: "Type of order, either 'limit' or 'market'."
             }
           )
 
@@ -35,7 +35,7 @@ module API
             documentation: {
               type: BigDecimal,
               desc: "Price for each unit. e.g."\
-                    "If you want to sell/buy 1 btc at 3000 usd, the price is '3000.0'"
+                    "If you want to sell/buy 1 btc at 3000 usd, the price is '3000.0'."
             }
           )
 
@@ -43,7 +43,7 @@ module API
             :avg_price,
             documentation: {
               type: BigDecimal,
-              desc: 'Average execution price, average of price in trades'
+              desc: 'Average execution price, average of price in trades.'
             }
           )
 
@@ -54,7 +54,7 @@ module API
               desc: "One of 'wait', 'done', 'pending', 'reject' or 'cancel'."\
                     "An order in 'wait' is an active order, waiting fulfillment;"\
                     "a 'done' order is an order fulfilled;"\
-                    "'cancel' means the order has been canceled"
+                    "'cancel' means the order has been canceled."
             }
           )
 
@@ -74,7 +74,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Order create time in iso8601 format'
+              desc: 'Order create time in iso8601 format.'
             }
           )
 
@@ -83,7 +83,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Order updated time in iso8601 format'
+              desc: 'Order updated time in iso8601 format.'
             }
           )
 
@@ -95,7 +95,7 @@ module API
                     "An order could be partially executed,"\
                     "e.g. an order sell 5 btc can be matched with a buy 3 btc order,"\
                     "left 2 btc to be sold; in this case the order's volume would be '5.0',"\
-                    "its remaining_volume would be '2.0', its executed volume is '3.0'"
+                    "its remaining_volume would be '2.0', its executed volume is '3.0'."
             }
           )
 
@@ -104,7 +104,7 @@ module API
             as: :remaining_volume,
             documentation: {
               type: BigDecimal,
-              desc: "The remaining volume, see 'volume'"
+              desc: "The remaining volume, see 'volume'."
             }
           )
 
@@ -112,7 +112,7 @@ module API
             :executed_volume,
             documentation: {
               type: BigDecimal,
-              desc: "The executed volume, see 'volume'"
+              desc: "The executed volume, see 'volume'."
             }
           ) do |order, _options|
               order.origin_volume - order.volume
@@ -122,7 +122,7 @@ module API
             :trades_count,
             documentation: {
               type: Integer,
-              desc: 'Count of trades'
+              desc: 'Count of trades.'
             }
           )
 
@@ -131,18 +131,18 @@ module API
             documentation: {
               type: 'API::V2::Entities::Trade',
               is_array: true,
-              desc: 'Trades with this order'
+              desc: 'Trades with this order.'
             },
             if: { type: :full }
           ) do |order, _options|
-              API::V2::Entities::Trade.represent order.trades, side: side
+              API::V2::Entities::Trade.represent order.trades, side: order.type == 'OrderAsk' ? 'sell' : 'buy'
             end
 
           expose(
             :email,
             documentation: {
               type: String,
-              desc: 'The shared user email'
+              desc: 'The shared user email.'
             }
           ) { |w| w.member.email }
 
@@ -150,16 +150,9 @@ module API
             :uid,
             documentation: {
               type: String,
-              desc: 'The shared user ID'
+              desc: 'The shared user ID.'
             }
           ) { |w| w.member.uid }
-
-          private
-
-          def side
-            @side ||= @object.type[-3, 3] == 'Ask' ? 'sell' : 'buy'
-          end
-
         end
       end
     end

--- a/app/api/v2/admin/entities/wallet.rb
+++ b/app/api/v2/admin/entities/wallet.rb
@@ -11,7 +11,7 @@ module API
             :id,
             documentation:{
               type: Integer,
-              desc: 'Unique wallet id'
+              desc: 'Unique wallet id.'
             }
           )
 
@@ -19,7 +19,7 @@ module API
             :name,
             documentation: {
                 type: String,
-                desc: 'Wallet name'
+                desc: 'Wallet name.'
             }
           )
 
@@ -27,7 +27,7 @@ module API
             :kind,
             documentation: {
                 type: String,
-                desc: "Kind of wallet 'deposit','fee','hot','warm' or 'cold'"
+                desc: "Kind of wallet 'deposit','fee','hot','warm' or 'cold'."
             }
           )
 
@@ -35,7 +35,7 @@ module API
             :currency_id,
             documentation: {
                 type: String,
-                desc: 'Wallet currency id'
+                desc: 'Wallet currency id.'
             }
           )
 
@@ -43,7 +43,7 @@ module API
             :address,
             documentation: {
                 type: String,
-                desc: 'Wallet address'
+                desc: 'Wallet address.'
             }
           )
 
@@ -51,7 +51,7 @@ module API
             :gateway,
             documentation: {
                 type: String,
-                desc: 'Wallet gateway'
+                desc: 'Wallet gateway.'
             }
           )
 
@@ -59,7 +59,7 @@ module API
             :nsig,
             documentation: {
                 type: Integer,
-                desc: 'Wallet number of signatures'
+                desc: 'Wallet number of signatures.'
             }
           )
 
@@ -67,7 +67,7 @@ module API
             :max_balance,
             documentation: {
                 type: BigDecimal,
-                desc: 'Wallet max balance'
+                desc: 'Wallet max balance.'
             }
           )
 
@@ -75,7 +75,7 @@ module API
             :parent,
             documentation: {
                 type: Integer,
-                desc: 'Wallet parent'
+                desc: 'Wallet parent.'
             }
           )
 
@@ -83,7 +83,7 @@ module API
             :blockchain_key,
             documentation: {
                 type: String,
-                desc: 'Wallet blockchain key'
+                desc: 'Wallet blockchain key.'
             }
           )
 
@@ -91,7 +91,7 @@ module API
             :status,
             documentation: {
                 type: String,
-                desc: 'Wallet status (active/disabled)'
+                desc: 'Wallet status (active/disabled).'
             }
           )
 
@@ -99,7 +99,7 @@ module API
             :settings,
             documentation: {
               type: JSON,
-              desc: 'Wallet settings'
+              desc: 'Wallet settings.'
             }
           )
 
@@ -108,7 +108,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Wallet created time in iso8601 format'
+              desc: 'Wallet created time in iso8601 format.'
             }
           )
 
@@ -117,7 +117,7 @@ module API
             format_with: :iso8601,
             documentation: {
               type: String,
-              desc: 'Wallet updated time in iso8601 format'
+              desc: 'Wallet updated time in iso8601 format.'
             }
           )
         end

--- a/app/api/v2/admin/entities/withdraw.rb
+++ b/app/api/v2/admin/entities/withdraw.rb
@@ -1,0 +1,169 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module Entities
+        class Withdraw < Base
+          expose(
+            :id,
+            documentation: {
+              type: Integer,
+              desc: 'The withdrawal id.'
+            }
+          )
+
+          expose(
+            :member_id,
+            as: :member,
+            documentation: {
+              type: String,
+              desc: 'The member id.'
+            }
+          )
+
+          expose(
+            :currency_id,
+            as: :currency,
+            documentation: {
+              type: String,
+              desc: 'The currency code.'
+            }
+          )
+
+          expose(
+            :account_id,
+            as: :account,
+            documentation: {
+              type: String,
+              desc: 'The account code.'
+            }
+          )
+
+          expose(
+            :attempts,
+            documentation: {
+              type: Integer,
+              desc: 'The withdraw attempts.'
+            }
+          )
+          expose(
+            :block_number,
+            documentation: {
+              type: Integer,
+              desc: 'The withdraw block_number.'
+            },
+            if: ->(w) { w.coin? }
+          )
+
+          expose(
+            :type,
+            documentation: {
+              type: String,
+              desc: 'The withdrawal type.'
+            }
+          ) { |w| w.fiat? ? :fiat : :coin }
+
+          expose(
+            :amount,
+            documentation: {
+              type: BigDecimal,
+              desc: 'The withdrawal amount.'
+            }
+          )
+
+          expose(
+            :sum,
+            documentation: {
+              type: BigDecimal,
+              desc: 'The withdrawal sum.'
+            }
+          )
+
+          expose(
+            :fee,
+            documentation: {
+              type: BigDecimal,
+              desc: 'The exchange fee.'
+            }
+          )
+
+          expose(
+            :txid,
+            as: :blockchain_txid,
+            documentation: {
+              type: String,
+              desc: 'The withdrawal transaction id.'
+            },
+            if: ->(w) { w.coin? }
+          )
+
+          expose(
+            :rid,
+            documentation: {
+              type: String,
+              desc: 'The beneficiary ID or wallet address on the Blockchain.'
+            },
+            if: ->(w) { w.coin? }
+          )
+
+          expose(
+            :aasm_state,
+            as: :state,
+            documentation: {
+              type: String,
+              desc: 'The withdrawal state.'
+            }
+          )
+
+          expose(
+            :confirmations,
+            if: ->(w) { w.coin? },
+            documentation: {
+              type: Integer,
+              desc: 'Number of confirmations.'
+            }
+          )
+
+          expose(
+            :tid,
+            documentation: {
+              type: String,
+              desc: 'Withdraw tid.'
+            }
+          )
+
+          expose(
+            :note,
+            documentation: {
+              type: String,
+              desc: 'Withdraw note.'
+            }
+          )
+
+          expose(
+            :created_at,
+            :updated_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetimes for the withdrawal.'
+            }
+          )
+
+          expose(
+            :completed_at,
+            as: :done_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when withdraw was completed.'
+            },
+            if: ->(w) { w.completed? }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/market_params.rb
+++ b/app/api/v2/admin/market_params.rb
@@ -8,52 +8,57 @@ module API
         extend ::Grape::API::Helpers
 
         params :create_market_params do
-          requires :ask_unit,
+          requires :base_unit,
                    type: String,
                    values: { value: -> { ::Currency.ids }, message: 'admin.market.currency_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:ask_unit][:desc] }
-          requires :bid_unit,
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:base_unit][:desc] }
+          requires :quote_unit,
                    type: String,
                    values: { value: -> { ::Currency.ids }, message: 'admin.market.currency_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:bid_unit][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:quote_unit][:desc] }
           optional :ask_fee,
                    type: { value: BigDecimal, message: 'admin.market.non_decimal_ask_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_ask_fee' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:ask_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:ask_fee][:desc] }
           optional :bid_fee,
                    type: { value: BigDecimal, message: 'admin.market.non_decimal_bid_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_bid_fee' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:bid_fee][:desc] }
-          optional :min_ask_price,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_ask_price' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_ask_price' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:bid_fee][:desc] }
+          optional :min_price,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_price' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_price' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_ask_price][:desc] }
-          optional :max_bid_price,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_max_bid_price' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_max_bid_price' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:min_price][:desc] }
+          optional :max_price,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_max_price' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_max_price' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:max_bid_price][:desc] }
-          optional :min_ask_amount,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_ask_amount' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_ask_amount' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:max_price][:desc] }
+          optional :min_amount,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_amount' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_amount' },
                    default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_ask_amount][:desc] }
-          optional :min_bid_amount,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_bid_amount' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_bid_amount' },
-                   default: 0.0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_bid_amount][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:min_amount][:desc] }
+          optional :amount_precision,
+                   type: { value: Integer, message: 'admin.market.non_integer_amount_precision' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_amount_precision' },
+                   default: 0,
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:amount_precision][:desc] }
+          optional :price_precision,
+                   type: { value: Integer, message: 'admin.market.non_integer_price_precision' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_price_precision' },
+                   default: 0,
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:price_precision][:desc] }
           optional :position,
                    type: { value: Integer, message: 'admin.market.non_integer_position' },
                    default: 0,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:position][:desc] }
-          optional :enabled,
-                   type: { value: Boolean, message: 'admin.market.non_boolean_enabled' },
-                   default: true,
-                   desc: -> { V2::Admin::Entities::Market.documentation[:enabled][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:position][:desc] }
+          optional :state,
+                   values: { value: ::Market::STATES, message: 'admin.market.invalid_state' },
+                   default: 'enabled',
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:state][:desc] }
         end
 
         params :update_market_params do
@@ -63,39 +68,36 @@ module API
           optional :ask_fee,
                    type: { value: BigDecimal, message: 'admin.market.non_decimal_ask_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_ask_fee' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:ask_fee][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:ask_fee][:desc] }
           optional :bid_fee,
                    type: { value: BigDecimal, message: 'admin.market.non_decimal_bid_fee' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_bid_fee' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:bid_fee][:desc] }
-          optional :min_ask_price,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_ask_price' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_ask_price' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_ask_price][:desc] }
-          optional :max_bid_price,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_max_bid_price' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_max_bid_price' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:max_bid_price][:desc] }
-          optional :min_ask_amount,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_ask_amount' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_ask_amount' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_ask_amount][:desc] }
-          optional :min_bid_amount,
-                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_bid_amount' },
-                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_bid_amount' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:min_bid_amount][:desc] }
-          optional :ask_precision,
-                   type: { value: Integer, message: 'admin.currency.non_integer_ask_precision' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:ask_precision][:desc] }
-          optional :bid_precision,
-                   type: { value: Integer, message: 'admin.currency.non_integer_bid_precision' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:bid_precision][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:bid_fee][:desc] }
+          optional :min_price,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_price' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_price' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:min_price][:desc] }
+          optional :max_price,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_max_price' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_max_price' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:max_price][:desc] }
+          optional :min_amount,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_min_amount' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_min_amount' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:min_amount][:desc] }
+          optional :amount_precision,
+                   type: { value: BigDecimal, message: 'admin.market.non_decimal_amount_precision' },
+                   values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_amount_precision' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:amount_precision][:desc] }
+          optional :price_precision,
+                   type: { value: Integer, message: 'admin.currency.non_integer_price_precision' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:price_precision][:desc] }
           optional :position,
                    type: { value: Integer, message: 'admin.market.non_integer_position' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:position][:desc] }
-          optional :enabled,
-                   type: { value: Boolean, message: 'admin.market.non_boolean_enabled' },
-                   desc: -> { V2::Admin::Entities::Market.documentation[:enabled][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:position][:desc] }
+          optional :state,
+                   values: { value: ::Market::STATES, message: 'admin.market.invalid_state' },
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:state][:desc] }
         end
       end
     end

--- a/app/api/v2/admin/mount.rb
+++ b/app/api/v2/admin/mount.rb
@@ -12,6 +12,8 @@ module API
         mount Admin::Currencies
         mount Admin::Markets
         mount Admin::Wallets
+        mount Admin::Deposits
+        mount Admin::Withdraws
       end
     end
   end

--- a/app/api/v2/admin/order_params.rb
+++ b/app/api/v2/admin/order_params.rb
@@ -11,7 +11,7 @@ module API
           optional :market,
                    type: String,
                    values: { value: -> { ::Market.enabled.ids }, message: 'admin.market.doesnt_exist' },
-                   desc: -> { V2::Entities::Market.documentation[:id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Market.documentation[:id][:desc] }
           optional :state,
                    type: String,
                    values: { value: -> { ::Order.state.values }, message: 'admin.order.invalid_state' },
@@ -23,21 +23,21 @@ module API
           optional :price,
                    type: { value: BigDecimal, message: 'admin.order.non_decimal_price' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.order.non_positive_price' },
-                   desc: -> { V2::Admin::Entities::Order.documentation[:price][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Order.documentation[:price][:desc] }
           optional :origin_volume,
                    type: { value: BigDecimal, message: 'admin.order.non_decimal_price' },
                    values: { value: -> (p){ p.try(:positive?) }, message: 'admin.order.non_positive_origin_volume' },
-                   desc: -> { V2::Admin::Entities::Order.documentation[:origin_volume][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Order.documentation[:origin_volume][:desc] }
           optional :type,
                    type: String,
                    values: { value: %w(buy sell), message: 'admin.order.invalid_type' },
                    desc: 'Filter order by type.'
           optional :email,
                    type: String,
-                   desc: -> { V2::Entities::Member.documentation[:email][:desc] }
+                   desc: -> { API::V2::Entities::Member.documentation[:email][:desc] }
           optional :uid,
                    type: String,
-                   desc: -> { V2::Entities::Member.documentation[:uid][:desc] }
+                   desc: -> { API::V2::Entities::Member.documentation[:uid][:desc] }
           optional :updated_at_from,
                    type: { value: Integer, message: 'admin.order.non_integer_updated_at_from' },
                    allow_blank: { value: false, message: 'admin.order.empty_time_from' },

--- a/app/api/v2/admin/orders.rb
+++ b/app/api/v2/admin/orders.rb
@@ -5,9 +5,10 @@ module API
   module V2
     module Admin
       class Orders < Grape::API
-        helpers ::API::V2::Admin::OrderParams
+        helpers API::V2::Admin::OrderParams
+        helpers API::V2::Admin::ParamsHelpers
 
-        desc 'Get all orders, results is paginated.',
+        desc 'Get all orders, result is paginated.',
           is_array: true,
           success: API::V2::Admin::Entities::Order
         params do
@@ -21,13 +22,14 @@ module API
                    allow_blank: false,
                    default: 1,
                    desc: 'Specify the page of paginated results.'
+          optional :ordering,
+                   type: String,
+                   values: { value: %w(asc desc), message: 'admin.order.invalid_ordering' },
+                   default: 'asc',
+                   desc: 'If set, returned orders will be sorted in specific order, default to \'asc\'.'
           optional :order_by,
                    type: String,
-                   values: { value: %w(asc desc), message: 'admin.order.invalid_order_by' },
-                   default: 'desc',
-                   desc: "If set, returned orders will be sorted in specific order, default to 'desc'."
-          optional :sort_field,
-                   type: String,
+                   default: 'id',
                    desc: 'Name of the field, which will be ordered by'
           use :order_params
         end
@@ -40,17 +42,17 @@ module API
             ord_type_eq: params[:ord_type],
             state_eq: params[:state].present? ? Order::STATES[params[:state].to_sym] : nil,
             market_id_eq: params[:market],
-            type_eq: params[:type].present? ? params[:type] == 'buy' ? 'OrderBid' : 'OrderAsk' : nil,
+            type_eq: params[:type].present? ? "Order#{params[:type].capitalize}" : nil,
             member_uid_eq: params[:uid],
             member_email_eq: params[:email],
-            created_at_gteq: params[:created_at_from].present? ? Time.at(params[:created_at_from]) : nil,
-            created_at_lt: params[:created_at_to].present? ? Time.at(params[:created_at_to]) : nil,
-            updated_at_gteq: params[:updated_at_from].present? ? Time.at(params[:updated_at_from]) : nil,
-            updated_at_lt: params[:updated_at_to].present? ? Time.at(params[:updated_at_to]) : nil
+            created_at_gteq: time_param(params[:created_at_from]),
+            created_at_lt: time_param(params[:created_at_to]),
+            updated_at_gteq: time_param(params[:updated_at_from]),
+            updated_at_lt: time_param(params[:updated_at_to])
           }
 
           search = Order.ransack(ransack_params)
-          search.sorts = "#{params[:sort_field]} #{params[:order_by]}" if params[:sort_field].present?
+          search.sorts = "#{params[:order_by]} #{params[:ordering]}"
           present paginate(search.result), with: API::V2::Admin::Entities::Order
         end
       end

--- a/app/api/v2/admin/params_helpers.rb
+++ b/app/api/v2/admin/params_helpers.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module ParamsHelpers
+
+        def time_param(param)
+          param.present? ? Time.at(param) : nil
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/wallet_params.rb
+++ b/app/api/v2/admin/wallet_params.rb
@@ -11,45 +11,45 @@ module API
           requires :blockchain_key,
                    type: String,
                    values: { value: -> { ::Blockchain.pluck(:key) }, message: 'admin.wallet.blockchain_key_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:blockchain_key][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:blockchain_key][:desc] }
           requires :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:name][:desc] }
           requires :address,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:address][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:address][:desc] }
           requires :currency_id,
                    type: String,
                    values: { value: -> { ::Currency.ids }, message: 'admin.wallet.currency_id_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:currency_id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:currency_id][:desc] }
           requires :kind,
                    type: String,
                    values: { value: ::Wallet.kind.values, message: 'admin.wallet.invalid_kind' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:kind][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:kind][:desc] }
           requires :gateway,
                    type: String,
                    values: { value: -> { ::Blockchain.pluck(:client) }, message: 'admin.wallet.gateway_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:gateway][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:gateway][:desc] }
           requires :settings,
                    type: { value: JSON, message: 'admin.wallet.non_json_settings' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:settings][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:settings][:desc] }
           optional :nsig,
                    type: { value: Integer, message: 'admin.wallet.non_integer_nsig' },
                    default: 1,
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:nsig][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:nsig][:desc] }
           optional :max_balance,
                    type: { value: BigDecimal, message: 'admin.blockchain.non_decimal_max_balance' },
                    default: 0.0,
                    values: { value: -> (p){ p >= 0 }, message: 'admin.wallet.invalid_max_balance' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:max_balance][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:max_balance][:desc] }
           optional :parent,
                    type: { value: String, message: 'admin.wallet.non_string_parent'},
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:parent][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:parent][:desc] }
           optional :status,
                    type: String,
                    values: { value: %w(active disabled), message: 'admin.wallet.invalid_status' },
                    default: 'active',
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:status][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:status][:desc] }
         end
 
         params :update_wallet_params do
@@ -59,42 +59,42 @@ module API
           optional :blockchain_key,
                    type: String,
                    values: { value: -> { ::Blockchain.pluck(:key) }, message: 'admin.wallet.blockchain_key_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:blockchain_key][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:blockchain_key][:desc] }
           optional :name,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:name][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:name][:desc] }
           optional :address,
                    type: String,
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:address][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:address][:desc] }
           optional :kind,
                    type: String,
                    values: { value: ::Wallet.kind.values, message: 'admin.wallet.invalid_kind' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:kind][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:kind][:desc] }
           optional :nsig,
                    type: { value: Integer, message: 'admin.wallet.non_integer_nsig' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:nsig][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:nsig][:desc] }
           optional :gateway,
                    type: String,
                    values: { value: -> { ::Blockchain.pluck(:client) }, message: 'admin.wallet.gateway_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:gateway][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:gateway][:desc] }
           optional :max_balance,
                    type: { value: BigDecimal, message: 'admin.blockchain.non_decimal_max_balance' },
                    values: { value: -> (p){ p >= 0 }, message: 'admin.wallet.invalid_max_balance' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:max_balance][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:max_balance][:desc] }
           optional :parent,
                    type: { value: String, message: 'admin.wallet.non_string_parent'},
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:parent][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:parent][:desc] }
           optional :status,
                    type: String,
                    values: { value: %w(active disabled), message: 'admin.wallet.invalid_status' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:status][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:status][:desc] }
           optional :currency_id,
                    type: String,
                    values: { value: -> { ::Currency.ids }, message: 'admin.wallet.currency_id_doesnt_exist' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:currency_id][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:currency_id][:desc] }
           optional :settings,
                    type: { value: String, message: 'admin.wallet.non_string_settings' },
-                   desc: -> { V2::Admin::Entities::Wallet.documentation[:settings][:desc] }
+                   desc: -> { API::V2::Admin::Entities::Wallet.documentation[:settings][:desc] }
         end
       end
     end

--- a/app/api/v2/admin/withdraw_params.rb
+++ b/app/api/v2/admin/withdraw_params.rb
@@ -1,0 +1,132 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module WithdrawParams
+        extend ::Grape::API::Helpers
+
+        COIN_ACTIONS = %w(process load reject)
+        FIAT_ACTIONS = %w(accept reject)
+
+        params :get_withdraws_params do
+          optional :currency,
+                   type: String,
+                   values: { value: -> { Currency.enabled.codes(bothcase: true) }, message: 'admin.currency.doesnt_exist' },
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:currency][:desc] }
+          optional :state,
+                   type: String,
+                   values: { value: -> { Withdraw::STATES.map(&:to_s) }, message: 'admin.withdraw.invalid_state' },
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:state][:desc] }
+          optional :limit,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_limit' },
+                   values: { value: 1..100, message: 'admin.withdraw.invalid_limit' },
+                   default: 100,
+                   desc: 'Number of withdraws per page (defaults to 100, maximum is 100).'
+          optional :page,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_page' },
+                   values: { value: -> (p){ p.try(:positive?) }, message: 'admin.withdraw.non_positive_page'},
+                   default: 1,
+                   desc: 'Page number (defaults to 1).'
+          optional :member,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:member][:desc] }
+          optional :account,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:account][:desc] }
+          optional :id,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:id][:desc] }
+          optional :txid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:blockchain_txid][:desc] }
+          optional :tid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:tid][:desc] }
+          optional :confirmations,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:confirmations][:desc] }
+          optional :rid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:rid][:desc] }
+          optional :type,
+                   type: String,
+                   values: { value: %w(fiat coin), message: 'admin.withdraw.invalid_type' },
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:type][:desc] }
+          optional :amount_from,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_amount_from' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_amount_from' },
+                   desc: 'If set, only withdraws with amount greater or equal then will be returned.'
+          optional :amount_to,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_amount_to' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_amount_to' },
+                   desc: 'If set, only withdraws with amount less then will be returned.'
+          optional :sum_from,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_sum_from' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_sum_from' },
+                   desc: 'If set, only withdraws with sum greater or equal then will be returned.'
+          optional :sum_to,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_sum_to' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_sum_to' },
+                   desc: 'If set, only withdraws with sum less then will be returned.'
+          optional :updated_at_from,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_updated_at_from' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws updated after the time will be returned."
+          optional :updated_at_to,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_updated_at_to' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws updated before the time will be returned."
+          optional :created_at_from,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_created_at_from' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws created after the time will be returned."
+          optional :created_at_to,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_created_at_to' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws created before the time will be returned."
+          optional :done_at_from,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_done_at_from' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_from' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws done after the time will be returned."
+          optional :done_at_to,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_done_at_to' },
+                   allow_blank: { value: false, message: 'admin.withdraw.empty_time_to' },
+                   desc: "An integer represents the seconds elapsed since Unix epoch."\
+                         "If set, only withdraws done before the time will be returned."
+          optional :ordering,
+                   type: String,
+                   values: { value: %w(asc desc), message: 'admin.withdraw.invalid_ordering' },
+                   default: 'asc',
+                   desc: 'If set, returned withdraws will be sorted in specific order, defaults to \'asc\'.'
+          optional :order_by,
+                   default: 'id',
+                   type: String,
+                   desc: 'Name of the field to order withdraws by.'
+        end
+
+        params :update_withdraw_params do
+          requires :id,
+                   type: Integer,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:id][:desc] }
+          requires :action,
+                   type: String,
+                   values: { value: -> { COIN_ACTIONS | FIAT_ACTIONS }, message: 'admin.withdraw.invalid_action' },
+                   desc: "Action to perform on withdraw. Valid actions for coin are #{COIN_ACTIONS}."\
+                         "Valid actions for fiat are #{FIAT_ACTIONS}."
+          given action: ->(action) { action == 'load' } do
+            requires :txid,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:blockchain_txid][:desc] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/withdraws.rb
+++ b/app/api/v2/admin/withdraws.rb
@@ -1,0 +1,96 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      class Withdraws < Grape::API
+        helpers API::V2::Admin::WithdrawParams
+        helpers API::V2::Admin::ParamsHelpers
+
+        desc 'Get all withdraws, result is paginated.',
+          is_array: true,
+          success: API::V2::Admin::Entities::Deposit
+        params do
+          use :get_withdraws_params
+        end
+        get '/withdraws' do
+          authorize! :read, Withdraw
+
+          ransack_params = {
+            aasm_state_eq: params[:state],
+            member_id_eq: params[:member],
+            account_id_eq: params[:account],
+            currency_id_eq: params[:currency],
+            id_eq: params[:id],
+            txid_eq: params[:txid],
+            rid_eq: params[:rid],
+            tid_eq: params[:tid],
+            amount_gteq: params[:amount_from],
+            amount_lt: params[:amount_to],
+            sum_gteq: params[:sum_from],
+            sum_lt: params[:sum_to],
+            type_eq: params[:type].present? ? "Withdraws::#{params[:type]}" : nil,
+            created_at_gteq: time_param(params[:created_at_from]),
+            created_at_lt: time_param(params[:created_at_to]),
+            updated_at_gteq: time_param(params[:updated_at_from]),
+            updated_at_lt: time_param(params[:updated_at_to]),
+            completed_at_gteq: time_param(params[:done_at_from]),
+            completed_at_lt: time_param(params[:done_at_to]),
+          }
+
+          search = Withdraw.ransack(ransack_params)
+          search.sorts = "#{params[:order_by]} #{params[:ordering]}"
+
+          present paginate(search.result), with: API::V2::Admin::Entities::Withdraw
+        end
+
+        desc 'Update withdraw.' do
+          success API::V2::Admin::Entities::Withdraw
+        end
+        params do
+          use :update_withdraw_params
+        end
+        post '/withdraws/update' do
+          authorize! :write, Withdraw
+
+          withdraw = Withdraw.find(params[:id])
+
+          if withdraw.fiat?
+            case params[:action]
+            when 'accept'
+              success = withdraw.transaction do
+                withdraw.accept!
+                withdraw.process!
+                withdraw.dispatch!
+                withdraw.success!
+              end
+              error!({ errors: ['admin.withdraw.cannot_accept'] }, 422) unless success
+            when 'reject'
+              error!({ errors: ['admin.withdraw.cannot_reject'] }, 422) unless withdraw.reject!
+            else
+              error!({ errors: ['admin.withdraw.invalid_action'] }, 422)
+            end
+          else
+            case params[:action]
+            when 'accept'
+              error!({ errors: ['admin.withdraw.cannot_accept'] }, 422) unless withdraw.accept!
+            when 'load'
+              success = withdraw.transaction do
+                withdraw.update!(txid: params[:txid])
+                withdraw.load!
+              end
+              error!({ errors: ['admin.withdraw.cannot_load'] }, 422) unless success
+            when 'reject'
+              error!({ errors: ['admin.withdraw.cannot_reject'] }, 422) unless withdraw.reject!
+            else
+              error!({ errors: ['admin.withdraw.invalid_action'] }, 422)
+            end
+          end
+
+          present withdraw.reload with: API::V2::Admin::Entities::Withdraw
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/entities/deposit.rb
+++ b/app/api/v2/entities/deposit.rb
@@ -41,6 +41,7 @@ module API
 
         expose(
           :txid,
+          as: :blockchain_txid,
           documentation: {
             type: String,
             desc: 'Deposit transaction id.'
@@ -76,6 +77,7 @@ module API
 
         expose(
           :completed_at,
+          as: :done_at,
           format_with: :iso8601,
           documentation: {
             type: String,

--- a/app/api/v2/exception_handlers.rb
+++ b/app/api/v2/exception_handlers.rb
@@ -12,6 +12,10 @@ module API::V2
           error!({ errors: errors_array }, 422)
         end
 
+        rescue_from Grape::Exceptions::MethodNotAllowed do |_e|
+          error!({ errors: 'server.method_not_allowed' }, 405)
+        end
+
         rescue_from Peatio::Auth::Error do |e|
           report_exception(e)
           error!({ errors: ['jwt.decode_and_verify'] }, 401)

--- a/app/api/v2/market/orders.rb
+++ b/app/api/v2/market/orders.rb
@@ -7,7 +7,7 @@ module API
       class Orders < Grape::API
         helpers ::API::V2::Market::NamedParams
 
-        desc 'Get your orders, results is paginated.',
+        desc 'Get your orders, result is paginated.',
           is_array: true,
           success: API::V2::Entities::Order
         params do

--- a/spec/api/v2/account/deposits_spec.rb
+++ b/spec/api/v2/account/deposits_spec.rb
@@ -61,7 +61,7 @@ describe API::V2::Account::Deposits, type: :request do
       result = JSON.parse(response.body)
 
       expect(result.size).to eq 1
-      expect(result.first['txid']).to eq d.txid
+      expect(result.first['blockchain_txid']).to eq d.txid
     end
 
     it 'returns deposits for currency usd' do

--- a/spec/api/v2/admin/blockchains_spec.rb
+++ b/spec/api/v2/admin/blockchains_spec.rb
@@ -43,7 +43,7 @@ describe API::V2::Admin::Blockchains, type: :request do
     end
 
     it 'returns blockchains by ascending order' do
-      api_get '/api/v2/admin/blockchains', params: { order_by: 'asc', sort_field: 'client'}, token: token
+      api_get '/api/v2/admin/blockchains', params: { ordering: 'asc', order_by: 'client'}, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful

--- a/spec/api/v2/admin/currencies_spec.rb
+++ b/spec/api/v2/admin/currencies_spec.rb
@@ -93,7 +93,7 @@ describe API::V2::Admin::Currencies, type: :request do
     end
 
     it 'returns currencies by ascending order' do
-      api_get '/api/v2/admin/currencies', params: { order_by: 'asc', sort_field: 'id'}, token: token
+      api_get '/api/v2/admin/currencies', params: { ordering: 'asc', order_by: 'id'}, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful

--- a/spec/api/v2/admin/deposits_spec.rb
+++ b/spec/api/v2/admin/deposits_spec.rb
@@ -1,0 +1,200 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe API::V2::Admin::Deposits, type: :request do
+  let(:admin) { create(:member, :admin, :level_3, email: 'example@gmail.com', uid: 'ID73BF61C8H0') }
+  let(:token) { jwt_for(admin) }
+  let(:level_3_member) { create(:member, :level_3) }
+  let(:level_3_member_token) { jwt_for(level_3_member) }
+  let!(:fiat_deposits) do
+    [
+      create(:deposit_usd, amount: 10.0),
+      create(:deposit_usd, amount: 9.0),
+      create(:deposit_usd, amount: 100.0, member: level_3_member),
+    ]
+  end
+  let!(:coin_deposits) do
+    [
+      create(:deposit_btc, amount: 102.0),
+      create(:deposit_btc, amount: 11.0, member: level_3_member),
+      create(:deposit_btc, amount: 12.0, member: level_3_member),
+    ]
+  end
+
+  describe 'GET /api/v2/admin/deposits' do
+    let(:url) { '/api/v2/admin/deposits' }
+
+    it 'get all deposits' do
+      api_get url, token: token
+
+      actual = JSON.parse(response.body)
+      expected = coin_deposits + fiat_deposits
+
+      expect(actual.length).to eq expected.length
+      expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+      expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+      expect(actual.map { |a| a['member'] }).to match_array expected.map(&:member_id)
+      expect(actual.map { |a| a['type'] }).to match_array(expected.map { |d| d.coin? ? 'coin' : 'fiat' })
+    end
+
+    context 'ordering' do
+      it 'ascending by id' do
+        api_get url, token: token, params: { order_by: 'id', ordering: 'asc' }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_deposits + fiat_deposits).sort { |a, b| a.id <=> b.id }
+
+        expect(actual.map { |a| a['id'] }).to eq expected.map(&:id)
+      end
+
+      it 'descending by amount' do
+        api_get url, token: token, params: { order_by: 'amount', ordering: 'desc' }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_deposits + fiat_deposits).sort { |a, b| b.amount <=> a.amount }
+
+        expect(actual.map { |a| a['id'] }).to eq expected.map(&:id)
+      end
+
+      it 'ordering by unexisting field' do
+        api_get url, token: token, params: { order_by: 'cutiness', ordering: 'desc' }
+
+        actual = JSON.parse(response.body)
+        expected = coin_deposits + fiat_deposits
+
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      end
+    end
+
+    context 'filtering' do
+      it 'by member' do
+        api_get url, token: token, params: { member: level_3_member.id }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_deposits + fiat_deposits).select { |d| d.member_id == level_3_member.id }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+        expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+        expect(actual.map { |a| a['member'] }).to all eq level_3_member.id
+        expect(actual.map { |a| a['type'] }).to match_array(expected.map { |d| d.coin? ? 'coin' : 'fiat' })
+      end
+
+      it 'by type' do
+        api_get url, token: token, params: { type: 'coin' }
+
+        actual = JSON.parse(response.body)
+        expected = coin_deposits
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+        expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+        expect(actual.map { |a| a['member'] }).to match_array expected.map(&:member_id)
+        expect(actual.map { |a| a['type'] }).to all eq 'coin'
+      end
+
+      it 'with upper amount bound' do
+        api_get url, token: token, params: { amount_to: 20 }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_deposits + fiat_deposits).select { |d| d.amount <= 20 }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      end
+
+      it 'with lower amount bound' do
+        api_get url, token: token, params: { amount_from: 20 }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_deposits + fiat_deposits).select { |d| d.amount >= 20 }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      end
+    end
+  end
+
+  describe 'POST /api/v2/admin/deposits/update' do
+    let(:url) { '/api/v2/admin/deposits/update' }
+    let(:fiat) { fiat_deposits.first }
+    let!(:coin) { create(:deposit, :deposit_trst, aasm_state: :accepted) }
+
+    context 'validates params' do
+      it 'does not pass unsupported action' do
+        api_post url, token: token, params: { action: 'illegal', id: fiat.id }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.deposit.invalid_action')
+      end
+
+      it 'passes supported action for coin' do
+        api_post url, token: token, params: { action: 'collect', id: coin.id }
+
+        expect(response).not_to include_api_error('admin.deposit.invalid_action')
+      end
+
+      it 'passes supported action for fiat' do
+        api_post url, token: token, params: { action: 'reject', id: fiat.id }
+
+        expect(response).not_to include_api_error('admin.deposit.invalid_action')
+      end
+
+      it 'does not pass fiat action for coin' do
+        api_post url, token: token, params: { action: 'reject', id: coin.id }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.deposit.invalid_action')
+      end
+
+      it 'does not pass coin action for fiat' do
+        api_post url, token: token, params: { action: 'collect_fee', id: fiat.id }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.deposit.invalid_action')
+      end
+    end
+
+    context 'updates deposit' do
+      it 'accept fiat' do
+        api_post url, token: token, params: { action: 'accept', id: fiat.id }
+
+        fiat.reload
+
+        expect(fiat.aasm_state).to eq('accepted')
+      end
+
+      it 'accept coin' do
+        api_post url, token: token, params: { action: 'accept', id: coin.id }
+
+        coin.reload
+
+        expect(coin.aasm_state).to eq('accepted')
+      end
+
+      it 'reject fiat' do
+        api_post url, token: token, params: { action: 'reject', id: fiat.id }
+
+        fiat.reload
+
+        expect(fiat.aasm_state).to eq('rejected')
+      end
+
+      it 'collect_fee coin' do
+        AMQPQueue.expects(:enqueue).with(:deposit_collection_fees, id: coin.id)
+
+        api_post url, token: token, params: { action: 'collect_fee', id: coin.id }
+      end
+
+      it 'collect coin' do
+        Deposit.any_instance.stubs(:may_dispatch? => true)
+        AMQPQueue.expects(:enqueue).with(:deposit_collection, id: coin.id)
+
+        api_post url, token: token, params: { action: 'collect', id: coin.id }
+      end
+    end
+  end
+end

--- a/spec/api/v2/admin/markets_spec.rb
+++ b/spec/api/v2/admin/markets_spec.rb
@@ -16,8 +16,8 @@ describe API::V2::Admin::Markets, type: :request do
 
       result = JSON.parse(response.body)
       expect(result.fetch('id')).to eq market.id
-      expect(result.fetch('ask_unit')).to eq market.ask_unit
-      expect(result.fetch('bid_unit')).to eq market.bid_unit
+      expect(result.fetch('base_unit')).to eq market.base_unit
+      expect(result.fetch('quote_unit')).to eq market.quote_unit
     end
 
     it 'returns error in case of invalid id' do
@@ -44,11 +44,11 @@ describe API::V2::Admin::Markets, type: :request do
     end
 
     it 'returns markets by ascending order' do
-      api_get '/api/v2/admin/markets', params: { order_by: 'asc', sort_field: 'bid_unit'}, token: token
+      api_get '/api/v2/admin/markets', params: { ordering: 'asc', order_by: 'quote_unit'}, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
-      expect(result.first['bid_unit']).to eq 'eth'
+      expect(result.first['quote_unit']).to eq 'eth'
     end
 
     it 'returns paginated markets' do
@@ -80,42 +80,42 @@ describe API::V2::Admin::Markets, type: :request do
 
   describe 'POST /api/v2/admin/markets/new' do
     it 'creates new market' do
-      api_post '/api/v2/admin/markets/new', params: { ask_unit: 'trst', bid_unit: 'btc' }, token: token
+      api_post '/api/v2/admin/markets/new', params: { base_unit: 'trst', quote_unit: 'btc' }, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
       expect(result['id']).to eq 'trstbtc'
     end
 
-    it 'validate ask_unit param' do
-      api_post '/api/v2/admin/markets/new', params: { ask_unit: 'test', bid_unit: 'btc' }, token: token
+    it 'validate base_unit param' do
+      api_post '/api/v2/admin/markets/new', params: { base_unit: 'test', quote_unit: 'btc' }, token: token
       expect(response).to have_http_status 422
       expect(response).to include_api_error('admin.market.currency_doesnt_exist')
     end
 
-    it 'validate bid_unit param' do
-      api_post '/api/v2/admin/markets/new', params: { ask_unit: 'trst', bid_unit: 'test' }, token: token
+    it 'validate quote_unit param' do
+      api_post '/api/v2/admin/markets/new', params: { base_unit: 'trst', quote_unit: 'test' }, token: token
       expect(response).to have_http_status 422
       expect(response).to include_api_error('admin.market.currency_doesnt_exist')
     end
 
     it 'validate enabled param' do
-      api_post '/api/v2/admin/markets/new', params: { ask_unit: 'trst', bid_unit: 'btc', enabled: '123'}, token: token
+      api_post '/api/v2/admin/markets/new', params: { base_unit: 'trst', quote_unit: 'btc', state: '123'}, token: token
 
       expect(response).to have_http_status 422
-      expect(response).to include_api_error('admin.market.non_boolean_enabled')
+      expect(response).to include_api_error('admin.market.invalid_state')
     end
 
     it 'checked required params' do
       api_post '/api/v2/admin/markets/new',params: { }, token: token
 
       expect(response).to have_http_status 422
-      expect(response).to include_api_error('admin.market.missing_ask_unit')
-      expect(response).to include_api_error('admin.market.missing_bid_unit')
+      expect(response).to include_api_error('admin.market.missing_base_unit')
+      expect(response).to include_api_error('admin.market.missing_quote_unit')
     end
 
     it 'return error in case of not permitted ability' do
-      api_post '/api/v2/admin/markets/new', params: { ask_unit: 'trst', bid_unit: 'btc' }, token: level_3_member_token
+      api_post '/api/v2/admin/markets/new', params: { base_unit: 'trst', quote_unit: 'btc' }, token: level_3_member_token
       expect(response.code).to eq '403'
       expect(response).to include_api_error('admin.ability.not_permitted')
     end

--- a/spec/api/v2/admin/orders_spec.rb
+++ b/spec/api/v2/admin/orders_spec.rb
@@ -82,8 +82,7 @@ describe API::V2::Admin::Orders, type: :request do
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
-      expect(result.map{|r| r['ord_type']}.uniq.size).to eq 1
-      expect(result.map{|r| r['ord_type']}.uniq.first).to eq 'limit'
+      expect(result.map{|r| r['ord_type']}).to all eq 'limit'
     end
 
     it 'returns orders with type sell' do
@@ -91,8 +90,7 @@ describe API::V2::Admin::Orders, type: :request do
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
-      expect(result.map{|r| r['side']}.uniq.size).to eq 1
-      expect(result.map{|r| r['side']}.uniq.first).to eq 'sell'
+      expect(result.map{|r| r['side']}).to all eq 'sell'
     end
 
     it 'returns orders for specific price' do
@@ -101,7 +99,7 @@ describe API::V2::Admin::Orders, type: :request do
 
       expect(response).to be_successful
       expect(result.map{|r| r['price']}.size).to eq 2
-      expect(result.map{|r| r['price']}.uniq.first).to eq '11.0'
+      expect(result.map{|r| r['price']}).to all eq '11.0'
     end
 
     it 'returns orders for specific origin_volume' do
@@ -110,7 +108,7 @@ describe API::V2::Admin::Orders, type: :request do
 
       expect(response).to be_successful
       expect(result.map{|r| r['origin_volume']}.size).to eq 5
-      expect(result.map{|r| r['origin_volume']}.uniq.first).to eq '123.1234'
+      expect(result.map{|r| r['origin_volume']}).to all eq '123.1234'
     end
 
     it 'returns orders for specific user by email' do
@@ -119,7 +117,7 @@ describe API::V2::Admin::Orders, type: :request do
 
       expect(response).to be_successful
       expect(result.map{|r| r['email']}.size).to eq 5
-      expect(result.map{|r| r['email']}.uniq.first).to eq 'example@gmail.com'
+      expect(result.map{|r| r['email']}).to all eq 'example@gmail.com'
     end
 
     it 'returns orders for specific user by uid' do
@@ -128,7 +126,7 @@ describe API::V2::Admin::Orders, type: :request do
 
       expect(response).to be_successful
       expect(result.map{|r| r['uid']}.size).to eq 5
-      expect(result.map{|r| r['uid']}.uniq.first).to eq 'ID73BF61C8H0'
+      expect(result.map{|r| r['uid']}).to all eq 'ID73BF61C8H0'
     end
 
     it 'returns paginated orders' do
@@ -148,7 +146,7 @@ describe API::V2::Admin::Orders, type: :request do
     end
 
     it 'returns orders by ascending order' do
-      api_get '/api/v2/admin/orders', params: { market: 'btcusd', order_by: 'asc', sort_field: 'updated_at'}, token: token
+      api_get '/api/v2/admin/orders', params: { market: 'btcusd', ordering: 'asc', order_by: 'updated_at'}, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful

--- a/spec/api/v2/admin/wallets_spec.rb
+++ b/spec/api/v2/admin/wallets_spec.rb
@@ -44,7 +44,7 @@ describe API::V2::Admin::Wallets, type: :request do
     end
 
     it 'returns wallets by ascending order' do
-      api_get '/api/v2/admin/wallets', params: { order_by: 'asc', sort_field: 'currency_id'}, token: token
+      api_get '/api/v2/admin/wallets', params: { ordering: 'asc', order_by: 'currency_id'}, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
@@ -102,7 +102,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate status' do
       api_post '/api/v2/admin/wallets/new', params: { name: 'Test', kind: 'deposit', currency_id: 'eth', address: 'blank', blockchain_key: 'btc-testnet', gateway: 'geth', settings: { uri: 'http://127.0.0.1:18332'}, status: 'disable' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.invalid_status')
@@ -110,7 +109,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate gateway' do
       api_post '/api/v2/admin/wallets/update', params: { name: 'Test', kind: 'deposit', currency_id: 'eth', address: 'blank', blockchain_key: 'btc-testnet', settings: { uri: 'http://127.0.0.1:18332'}, gateway: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.gateway_doesnt_exist')
@@ -118,7 +116,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate kind' do
       api_post '/api/v2/admin/wallets/update', params: { name: 'Test', kind: 'test', currency_id: 'eth', address: 'blank', blockchain_key: 'btc-testnet', settings: { uri: 'http://127.0.0.1:18332'}, gateway: 'geth' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.invalid_kind')
@@ -126,7 +123,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate currency_id' do
       api_post '/api/v2/admin/wallets/update', params: { name: 'Test', kind: 'deposit', address: 'blank', blockchain_key: 'btc-testnet', gateway: 'geth', settings: { uri: 'http://127.0.0.1:18332'}, currency_id: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.currency_id_doesnt_exist')
@@ -151,7 +147,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate blockchain_key' do
       api_post '/api/v2/admin/wallets/update', params: { id: Wallet.first.id, blockchain_key: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.blockchain_key_doesnt_exist')
@@ -159,7 +154,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate status' do
       api_post '/api/v2/admin/wallets/update', params: { id: Wallet.first.id, status: 'disable' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.invalid_status')
@@ -167,7 +161,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate gateway' do
       api_post '/api/v2/admin/wallets/update', params: { id: Wallet.first.id, gateway: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.gateway_doesnt_exist')
@@ -175,7 +168,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate kind' do
       api_post '/api/v2/admin/wallets/update', params: { id: Wallet.first.id, kind: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.invalid_kind')
@@ -183,7 +175,6 @@ describe API::V2::Admin::Wallets, type: :request do
 
     it 'validate currency_id' do
       api_post '/api/v2/admin/wallets/update', params: { id: Wallet.first.id, currency_id: 'test' }, token: token
-      result = JSON.parse(response.body)
 
       expect(response.code).to eq '422'
       expect(response).to include_api_error('admin.wallet.currency_id_doesnt_exist')

--- a/spec/api/v2/admin/withdraws_spec.rb
+++ b/spec/api/v2/admin/withdraws_spec.rb
@@ -1,0 +1,212 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe API::V2::Admin::Withdraws, type: :request do
+  let(:admin) { create(:member, :admin, :level_3, email: 'example@gmail.com', uid: 'ID73BF61C8H0') }
+  let(:token) { jwt_for(admin) }
+  let(:level_3_member) { create(:member, :level_3) }
+  let(:level_3_member_token) { jwt_for(level_3_member) }
+  let!(:fiat_withdraws) do
+    [
+      create(:usd_withdraw, amount: 10.0, sum: 10.0),
+      create(:usd_withdraw, amount: 9.0, sum: 9.0),
+      create(:usd_withdraw, amount: 100.0, sum: 100.0, member: level_3_member),
+    ]
+  end
+  let!(:coin_withdraws) do
+    [
+      create(:btc_withdraw, amount: 42.0, sum: 42.0, txid: 'special_txid'),
+      create(:btc_withdraw, amount: 11.0, sum: 11.0, member: level_3_member),
+      create(:btc_withdraw, amount: 12.0, sum: 12.0, member: level_3_member),
+    ]
+  end
+
+  describe 'GET /api/v2/admin/withdraws' do
+    let(:url) { '/api/v2/admin/withdraws' }
+
+    it 'get all withdraws' do
+      api_get url, token: token
+
+      actual = JSON.parse(response.body)
+      expected = coin_withdraws + fiat_withdraws
+
+      expect(actual.length).to eq expected.length
+      expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+      expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+      expect(actual.map { |a| a['member'] }).to match_array expected.map(&:member_id)
+      expect(actual.map { |a| a['type'] }).to match_array(expected.map { |d| d.coin? ? 'coin' : 'fiat' })
+    end
+
+    context 'ordering' do
+      it 'ascending by id' do
+        api_get url, token: token, params: { order_by: 'id', ordering: 'asc' }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_withdraws + fiat_withdraws).sort { |a, b| a.id <=> b.id }
+
+        expect(actual.map { |a| a['id'] }).to eq expected.map(&:id)
+      end
+
+      it 'descending by sum' do
+        api_get url, token: token, params: { order_by: 'sum', ordering: 'desc' }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_withdraws + fiat_withdraws).sort { |a, b| b.sum <=> a.sum }
+
+        expect(actual.map { |a| a['id'] }).to eq expected.map(&:id)
+      end
+    end
+
+    context 'filtering' do
+      it 'by member' do
+        api_get url, token: token, params: { member: level_3_member.id }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_withdraws + fiat_withdraws).select { |d| d.member_id == level_3_member.id }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+        expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+        expect(actual.map { |a| a['member'] }).to all eq level_3_member.id
+        expect(actual.map { |a| a['type'] }).to match_array(expected.map { |d| d.coin? ? 'coin' : 'fiat' })
+      end
+
+      it 'by type' do
+        api_get url, token: token, params: { type: 'coin' }
+
+        actual = JSON.parse(response.body)
+        expected = coin_withdraws
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['state'] }).to match_array expected.map(&:aasm_state)
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+        expect(actual.map { |a| a['currency'] }).to match_array expected.map(&:currency_id)
+        expect(actual.map { |a| a['member'] }).to match_array expected.map(&:member_id)
+        expect(actual.map { |a| a['type'] }).to all eq 'coin'
+      end
+
+      it 'by txid' do
+        api_get url, token: token, params: { txid: coin_withdraws.first.txid }
+
+        actual = JSON.parse(response.body)
+        expected = coin_withdraws.first
+
+        expect(actual.length).to eq 1
+        expect(actual.first['state']).to eq expected.aasm_state
+        expect(actual.first['id']).to eq expected.id
+        expect(actual.first['currency']).to eq expected.currency_id
+        expect(actual.first['member']).to eq expected.member_id
+        expect(actual.first['type']).to eq 'coin'
+      end
+
+      it 'with upper sum bound' do
+        api_get url, token: token, params: { sum_to: 20 }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_withdraws + fiat_withdraws).select { |d| d.sum <= 20 }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      end
+
+      it 'with lower sum bound' do
+        api_get url, token: token, params: { sum_from: 20 }
+
+        actual = JSON.parse(response.body)
+        expected = (coin_withdraws + fiat_withdraws).select { |d| d.sum >= 20 }
+
+        expect(actual.length).to eq expected.length
+        expect(actual.map { |a| a['id'] }).to match_array expected.map(&:id)
+      end
+    end
+  end
+
+  describe 'POST /api/v2/admin/withdraws/update' do
+    let(:url) { '/api/v2/admin/withdraws/update' }
+    let(:fiat) { fiat_withdraws.first }
+    let(:coin) { coin_withdraws.first }
+
+    context 'validates params' do
+      it 'does not pass unsupported action' do
+        api_post url, token: token, params: { action: 'illegal', id: fiat.id }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.withdraw.invalid_action')
+      end
+
+      it 'passes supported action for coin' do
+        api_post url, token: token, params: { action: 'accept', id: coin.id }
+
+        expect(response).not_to include_api_error('admin.withdraw.invalid_action')
+      end
+
+      it 'passes supported action for fiat' do
+        api_post url, token: token, params: { action: 'reject', id: fiat.id }
+
+        expect(response).not_to include_api_error('admin.withdraw.invalid_action')
+      end
+
+      it 'does not pass coin action for fiat' do
+        api_post url, token: token, params: { action: 'load', id: fiat.id, txid: 'txid' }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.withdraw.invalid_action')
+      end
+
+      it 'requests txid on load' do
+        api_post url, token: token, params: { action: 'load', id: coin.id }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.withdraw.missing_txid')
+      end
+    end
+
+    context 'updates withdraw' do
+      before { [coin, fiat].map(&:submit!) }
+
+      it 'accept fiat' do
+        api_post url, token: token, params: { action: 'accept', id: fiat.id }
+
+        fiat.reload
+
+        expect(fiat.aasm_state).to eq('succeed')
+      end
+
+      it 'accept coin' do
+        api_post url, token: token, params: { action: 'accept', id: coin.id }
+
+        coin.reload
+
+        expect(coin.aasm_state).to eq('accepted')
+      end
+
+      it 'reject fiat' do
+        api_post url, token: token, params: { action: 'reject', id: fiat.id }
+
+        fiat.reload
+
+        expect(fiat.aasm_state).to eq('rejected')
+      end
+
+      it 'reject coin' do
+        api_post url, token: token, params: { action: 'reject', id: coin.id }
+
+        coin.reload
+
+        expect(coin.aasm_state).to eq('rejected')
+      end
+
+      it 'load coin' do
+        api_post url, token: token, params: { action: 'accept', id: coin.id }
+        api_post url, token: token, params: { action: 'load', id: coin.id, txid: 'new_txid' }
+
+        coin.reload
+
+        expect(coin.txid).to eq('new_txid')
+        expect(coin.aasm_state).to eq('confirming')
+      end
+    end
+  end
+end

--- a/spec/models/order_ask_spec.rb
+++ b/spec/models/order_ask_spec.rb
@@ -31,7 +31,7 @@ describe OrderAsk do
       expect(bid).to eq('1010'.to_d * OrderBid::LOCKING_BUFFER_FACTOR)
     end
 
-    it 'should make sure price is greater than min_ask_price' do
+    it 'should make sure price is greater than min_price' do
       ask = OrderAsk.new(market_id: market.id, price: '0.0'.to_d, ord_type: 'limit')
       expect(ask).not_to be_valid
       expect(ask.errors[:price]).to include "must be greater than or equal to #{market.min_price}"

--- a/spec/support/rspec_matchers.rb
+++ b/spec/support/rspec_matchers.rb
@@ -22,7 +22,8 @@ RSpec::Matchers.define :include_api_error do |expected|
     raise 'actual doesnt respond to body' unless actual.respond_to?(:body)
     raise 'expected is not a String' unless expected.is_a? String
 
-    expected.in?(JSON.parse(actual.body)['errors'])
+    errors = JSON.parse(actual.body)['errors']
+    !errors.nil? && expected.in?(errors)
   end
 
   # TODO: Better Error message. Same as in module RSpec::Matchers::BuiltIn::Include


### PR DESCRIPTION
 - Update market admin api
 - Rename sort_field to order_by
 - Use declared params to prevent 5xx errors in api
 - Add API for withdraws
 - Update entities and specs
 - Return errors in withdraw/deposit api
 - Return 405 MethodNotAllowed instead of 500 Internal error