### PR TITLE
Fix: change min level for deposit

### DIFF
--- a/config/templates/application.yml.erb
+++ b/config/templates/application.yml.erb
@@ -95,7 +95,7 @@ defaults: &defaults
   DISPLAY_CURRENCY: usd
 
   # Configuration variables for dynamic Barong levels (1.8+).
-  MINIMUM_MEMBER_LEVEL_FOR_DEPOSIT:  '3'
+  MINIMUM_MEMBER_LEVEL_FOR_DEPOSIT:  '2'
   MINIMUM_MEMBER_LEVEL_FOR_WITHDRAW: '3'
   MINIMUM_MEMBER_LEVEL_FOR_TRADING:  '3'
 


### PR DESCRIPTION
User that confirmed phone number can make deposits. Currently user get stuck with no ability to deposit while he see message on the wallet page that he need to verify phone number, when he already did it.