### PR TITLE
Fix double spending issue on withdraw

### DIFF
--- a/app/controllers/admin/withdraws/coins_controller.rb
+++ b/app/controllers/admin/withdraws/coins_controller.rb
@@ -27,6 +27,8 @@ module Admin
           process!
         when 'load'
           load!
+        when 'approve'
+          approve!
         end
       end
 
@@ -46,6 +48,14 @@ module Admin
         @withdraw.transaction do
           @withdraw.accept!
           @withdraw.process!
+        end
+        redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated.'
+      end
+
+      def approve!
+        @withdraw.transaction do
+          @withdraw.update!(txid: params.fetch(:txid))
+          @withdraw.success!
         end
         redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated.'
       end

--- a/app/views/admin/withdraws/coins/show.html.erb
+++ b/app/views/admin/withdraws/coins/show.html.erb
@@ -28,13 +28,21 @@
           <% end %>
           <%= item_for @withdraw, :amount %>
           <hr>
-          <% if (can? :manage, Withdraw) && (@withdraw.may_accept? || @withdraw.may_process? || @withdraw.confirming?) %>
+          <% if (can? :manage, Withdraw) && !@withdraw.undefined? && (@withdraw.may_accept? || @withdraw.may_process? || @withdraw.confirming?) %>
             <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
               <%= form_tag admin_withdraw_path(event: 'load'), method: 'PATCH' do -%>
                 <%= text_field_tag :txid, nil, placeholder: 'Set txid here...', class: 'form-control w-50 d-inline ml-4' %>
-                <%= submit_tag 'Load withdraw', class: 'btn btn-primary float-left' %>
+                <%= submit_tag 'Load withdrawal', class: 'btn btn-primary float-left' %>
               <% end -%>
             </ul>
+          <% end %>
+          <% if (can? :write, Withdraw) && @withdraw.undefined? %>
+              <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
+                <%= form_tag admin_withdraw_path(event: 'approve'), method: 'PATCH' do -%>
+                  <%= text_field_tag :txid, nil, placeholder: 'Set txid here...', class: 'form-control w-50 d-inline ml-4' %>
+                  <%= submit_tag 'Approve withdrawal', class: 'btn btn-primary float-left' %>
+                <% end -%>
+              </ul>
           <% end %>
           <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
             <% if can? :write, Withdraw %>
@@ -51,6 +59,14 @@
                   <%= link_to 'Process',
                               admin_withdraw_path(event: 'process'),
                               class: 'btn btn-primary float-left',
+                              method: 'PATCH' %>
+                </li>
+              <% end %>
+              <% if @withdraw.undefined? && @withdraw.may_fail? %>
+                <li>
+                  <%= link_to 'Fail',
+                              admin_withdraw_path(event: 'fail'),
+                              class:   'btn btn-danger float-right',
                               method: 'PATCH' %>
                 </li>
               <% end %>

--- a/app/workers/amqp/withdraw_coin.rb
+++ b/app/workers/amqp/withdraw_coin.rb
@@ -77,22 +77,28 @@ module Workers
           withdraw.dispatch
           withdraw.save!
 
-          @logger.warn id: withdraw.id, message: 'OK.'
+          @logger.warn id: withdraw.id, message: 'Withdrawal has processed'
 
-        rescue Exception => e
-          begin
-            @logger.error id: withdraw.id,
-                          message: 'Failed to process withdraw. See exception details below.'
+        rescue StandardError => e
+          # TODO: Rescue {Plugin}::Client::ServerError after update in each plugin.
+          if e.is_a?(Peatio::Wallet::ClientError) && e.cause.cause.is_a?(Faraday::TimeoutError)
+            @logger.warn id: withdraw.id, message: 'Withdrawal status is undefined. Admin should check withdraw state manually'
             report_exception(e)
-            @logger.warn id: withdraw.id,
-                         message: 'Setting withdraw state to failed.'
-          ensure
+            withdraw.undefine!
+          else
+            @logger.error id: withdraw.id,
+                          message: 'Failed to process withdrawal. See exception details below.'
+            report_exception(e)
+
             if withdraw.may_process?
+              @logger.warn id: withdraw.id,
+                           message: 'Processing withdrawal again.'
               withdraw.process!
             else
               withdraw.fail!
+              @logger.warn id: withdraw.id,
+                           message: 'Setting withdrawal state to failed.'
             end
-            @logger.warn id: withdraw.id, message: 'OK.'
           end
         end
       end

--- a/lib/peatio/bitcoin/wallet.rb
+++ b/lib/peatio/bitcoin/wallet.rb
@@ -52,7 +52,7 @@ module Bitcoin
 
     def client
       uri = @wallet.fetch(:uri) { raise Peatio::Wallet::MissingSettingError, :uri }
-      @client ||= Client.new(uri)
+      @client ||= Client.new(uri, idle_timeout: 1)
     end
   end
 end

--- a/lib/peatio/ethereum/client.rb
+++ b/lib/peatio/ethereum/client.rb
@@ -1,7 +1,23 @@
 module Ethereum
   class Client
     Error = Class.new(StandardError)
-    class ConnectionError < Error;
+
+    class ConnectionError < Error; end
+
+    class ServerError < Error
+      attr_reader :wrapped_exception
+
+      def initialize(exc)
+        @wrapped_exception = exc
+      end
+
+      def backtrace
+        if @wrapped_exception
+          @wrapped_exception.backtrace
+        else
+          super
+        end
+      end
     end
 
     class ResponseError < Error
@@ -17,9 +33,10 @@ module Ethereum
 
     extend Memoist
 
-    def initialize(endpoint)
+    def initialize(endpoint, idle_timeout: 5)
       @json_rpc_endpoint = URI.parse(endpoint)
       @json_rpc_call_id = 0
+      @idle_timeout = idle_timeout
     end
 
     def json_rpc(method, params = [])
@@ -30,16 +47,15 @@ module Ethereum
            'Content-Type' => 'application/json'}
       response.assert_success!
       response = JSON.parse(response.body)
-      response['error'].tap {|error| raise ResponseError.new(error['code'], error['message']) if error}
+      response['error'].tap { |error| raise ResponseError.new(error['code'], error['message']) if error }
       response.fetch('result')
-    rescue => e
-      if e.is_a?(Error)
-        raise e
-      elsif e.is_a?(Faraday::Error)
-        raise ConnectionError, e
-      else
-        raise Error, e
-      end
+    # TODO: Rescue ServerError in daemons that provide ability to create blockchain transactions.
+    rescue Faraday::TimeoutError => e
+      raise ServerError, e
+    rescue Faraday::Error => e
+      raise ConnectionError, e
+    rescue StandardError => e
+      raise Error, e
     end
 
     private
@@ -50,7 +66,7 @@ module Ethereum
 
     def connection
       @connection ||= Faraday.new(@json_rpc_endpoint) do |f|
-        f.adapter :net_http_persistent, pool_size: 5
+        f.adapter :net_http_persistent, pool_size: 5, idle_timeout: @idle_timeout
       end.tap do |connection|
         unless @json_rpc_endpoint.user.blank?
           connection.basic_auth(@json_rpc_endpoint.user, @json_rpc_endpoint.password)

--- a/lib/peatio/ethereum/wallet.rb
+++ b/lib/peatio/ethereum/wallet.rb
@@ -175,7 +175,7 @@ module Ethereum
 
     def client
       uri = @wallet.fetch(:uri) { raise Peatio::Wallet::MissingSettingError, :uri }
-      @client ||= Client.new(uri)
+      @client ||= Client.new(uri, idle_timeout: 1)
     end
   end
 end

--- a/spec/workers/withdraw_coin_spec.rb
+++ b/spec/workers/withdraw_coin_spec.rb
@@ -125,4 +125,28 @@ describe Workers::AMQP::WithdrawCoin do
       expect(processing_withdrawal.txid).to eq('hash-1')
     end
   end
+
+  context 'marks withdraw as undefined on Faraday::TimeoutError error' do
+    before do
+      WalletService.any_instance
+                   .expects(:load_balance!)
+                   .returns(withdrawal.amount)
+
+      Bitcoin::Client.any_instance
+                   .expects(:connection)
+                   .raises(Faraday::TimeoutError.new)
+    end
+
+    subject { Workers::AMQP::WithdrawCoin.new.process(processing_withdrawal.as_json) }
+
+    it 'sets undefined state after processing withdrawal' do
+      expect(subject).to be_truthy
+      expect(processing_withdrawal.reload.undefined?).to be_truthy
+    end
+
+    it 'doesn\'t retry on time-out error' do
+      expect(Workers::AMQP::WithdrawCoin.new.process(processing_withdrawal.as_json)).to be_truthy
+      expect(processing_withdrawal.reload.undefined?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
- Fix issue with `too many connection resets` by specifying `idle_timeout=1s`.
- Add new state for withdraw: `undefined`. 
- Add admin ability to approve of fail withdrawal with state `undefined`. 
- Add new error class ServerError in Ethereum and Bitcoin Client, raise it when get Faraday::TimeoutError.
- In case when rescue `Peatio::Wallet::ClientError` with `Faraday::TimeoutError` cause set withdrawal state to `undefined`. 

State means admin should manually check, if blockchain transaction was created or not.