### PR TITLE
Market & Currency admin forms corrections & improvements

### DIFF
--- a/app/controllers/admin/markets_controller.rb
+++ b/app/controllers/admin/markets_controller.rb
@@ -44,22 +44,22 @@ module Admin
     end
 
     def permitted_market_attributes
-      attributes = [
-        :quote_unit,
-        :bid_fee,
-        :base_unit,
-        :ask_fee,
-        :state,
-        :min_price,
-        :max_price,
-        :min_amount,
-        :position
+      attributes = %i[
+        base_currency
+        quote_currency
+        base_currency_fee
+        quote_currency_fee
+        state
+        min_price
+        max_price
+        min_amount
+        position
       ]
 
       if @market.new_record?
-        attributes += [
-          :amount_precision,
-          :price_precision
+        attributes += %i[
+          amount_precision
+          price_precision
         ]
       end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,26 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+# We use the next convention for organizing Ruby on Rails Models.
+# https://www.zmwolski.com/Organizing-Ruby-on-Rails-Models
 class ApplicationRecord < ActiveRecord::Base
+  # == Constants ============================================================
+
+  # == Attributes ===========================================================
+
+  # == Extensions ===========================================================
+
+  # == Relationships ========================================================
+
+  # == Validations ==========================================================
+
+  # == Scopes ===============================================================
+
+  # == Callbacks ============================================================
+
+  # == Class Methods ========================================================
+
+  # == Instance Methods =====================================================
+
   self.abstract_class = true
 end

--- a/app/views/admin/deposits/coins/_table.html.erb
+++ b/app/views/admin/deposits/coins/_table.html.erb
@@ -1,24 +1,24 @@
 <div class="card">
   <%= table_for deposits, class: 'table table-bordered table-striped' do |t| %>
-    <% t.column :txid do |x| %>
+    <% t.column 'TXID' do |x| %>
       <a href="<%= x.transaction_url %>" target="_blank">
         <code class="text-info"><%= x.txid.truncate(36) %></code>
       </a>
     <% end %>
-    <% t.column :created_at %>
+    <% t.column :created_at, 'Created At' %>
     <% t.column 'Currency' do |x| %>
       <% x.currency.code.upcase %>
     <% end %>
-    <% t.column 'Member email' do |x| %>
+    <% t.column 'Member Email' do |x| %>
       <%= link_to x.member.email, url_for([:admin, x.member]), target: '_blank' %>
     <% end %>
-    <% t.column :amount do |x| %>
+    <% t.column 'Amount' do |x| %>
       <code class="text-info"><%= x.amount %></code>
     <% end %>
-    <% t.column :confirmations do |x| %>
+    <% t.column 'Confirmations' do |x| %>
       <span class="badge"><%= x.confirmations %></span>
     <% end %>
-    <% t.column :state_and_actions do |x| %>
+    <% t.column 'State/Actions' do |x| %>
       <span><%= x.aasm_state.humanize %></span>
       <% if can? :write, Deposit%>
         <% if x.may_accept? %>

--- a/app/views/admin/deposits/fiats/_table.html.erb
+++ b/app/views/admin/deposits/fiats/_table.html.erb
@@ -1,14 +1,14 @@
 <% unless deposits.empty? %>
   <%= table_for deposits, class: 'table table-bordered table-striped' do |t| %>
     <% t.column :id, 'Deposit ID' %>
-    <% t.column :created_at, 'Created at' %>
+    <% t.column :created_at, 'Created At' %>
     <% t.column 'Currency' do |x| %>
       <%= x.currency.code.upcase %>
     <% end %>
     <% t.column 'Member email' do |x| %>
       <%= link_to x.member.email, url_for([:admin, x.member]) %>
     <% end %>
-    <% t.column :amount do |x| %>
+    <% t.column 'Amount' do |x| %>
       <code class="text-info"><%= number_with_precision(x.amount, precision: 2) %></code>
     <% end %>
     <% t.column 'State' do |x| %>

--- a/app/views/admin/markets/index.html.erb
+++ b/app/views/admin/markets/index.html.erb
@@ -14,9 +14,9 @@
     <%= table_for @markets, class: 'table table-bordered table-striped' do |t| %>
       <% t.column :name, 'Name', class: 'col-xs-2' %>
 
-      <% t.column :bid_fee, 'Bid fee', class: 'col-xs-2' %>
+      <% t.column :base_currency_fee, 'Base Currency Fee', class: 'col-xs-2' %>
 
-      <% t.column :ask_fee, 'Ask fee', class: 'col-xs-2' %>
+      <% t.column :quote_currency_fee, 'Quote Currency Fee', class: 'col-xs-2' %>
 
       <% t.column 'Min amount', class: 'col-xs-2' do |x| %>
         <%= x.min_amount %>

--- a/app/views/admin/markets/show.html.erb
+++ b/app/views/admin/markets/show.html.erb
@@ -9,23 +9,23 @@
       <div class="card">
         <div class="card-body">
           <div class="form-group">
-            <label>Quote currency</label>
+            <label>Quote Currency</label>
             <% if @market.new_record? %>
-              <%= f.select :quote_unit, Currency.codes.map { |code| [code.upcase, code] }, {}, { class: "form-control mb-3" } %>
+              <%= f.select :quote_currency, Currency.codes.map { |code| [code.upcase, code] }, {}, { class: "form-control mb-3" } %>
             <% else %>
               <div class="mb-3"><%= @market.quote_unit.upcase %></div>
             <% end %>
 
-            <label>Quote currency fee</label>
-            <%= f.text_field :ask_fee, class: 'form-control mb-3' %>
+            <label>Quote Currency Fee</label>
+            <%= f.number_field :quote_currency_fee, step: :any, class: 'form-control mb-3' %>
 
             <label>Maximum Price</label>
-            <%= f.text_field :max_price, class: 'form-control mb-3' %>
+            <%= f.number_field :max_price, step: :any, class: 'form-control mb-3' %>
 
             <label>Minimum Amount</label>
-            <%= f.text_field :min_amount, class: 'form-control mb-3' %>
+            <%= f.number_field :min_amount, step: :any, class: 'form-control mb-3' %>
 
-            <label>Price precision</label>
+            <label>Price Precision</label>
             <% if @market.new_record? %>
               <%= f.number_field :price_precision, class: 'form-control mb-3' %>
             <% else %>
@@ -38,20 +38,20 @@
       <div class="card">
         <div class="card-body">
           <div class="form-group">
-            <label>Base currency</label>
+            <label>Base Currency</label>
             <% if @market.new_record? %>
-              <%= f.select :base_unit, Currency.codes.map { |code| [code.upcase, code] }, {}, { class: "form-control mb-3" } %>
+              <%= f.select :base_currency, Currency.codes.map { |code| [code.upcase, code] }, {}, { class: "form-control mb-3" } %>
             <% else %>
               <div class="mb-3"><%= @market.base_unit.upcase %></div>
             <% end %>
 
-            <label>Base currency fee</label>
-            <%= f.text_field :bid_fee, class: 'form-control mb-3' %>
+            <label>Base Currency Fee</label>
+            <%= f.number_field :base_currency_fee, step: :any, class: 'form-control mb-3' %>
 
             <label>Minimum Price</label>
-            <%= f.text_field :min_price, class: 'form-control mb-3' %>
+            <%= f.number_field :min_price, step: :any, class: 'form-control mb-3' %>
 
-            <label>Amount precision</label>
+            <label>Amount Precision</label>
             <% if @market.new_record? %>
               <%= f.number_field :amount_precision, class: 'form-control' %>
             <% else %>

--- a/app/views/admin/withdraws/coins/_pending_table.html.erb
+++ b/app/views/admin/withdraws/coins/_pending_table.html.erb
@@ -1,11 +1,11 @@
 <%= table_for withdraws, class: 'table table-bordered table-striped', model: Withdraws::Coin do |t| %>
-  <% t.column :id %>
-  <% t.column :txid do |x| %>
+  <% t.column :id, 'Withdrawal ID' %>
+  <% t.column 'TXID' do |x| %>
     <a href="<%= x.transaction_url %>" target="_blank">
       <code class="text-info"><%= x.txid%></code>
     </a>
   <% end %>
-  <% t.column :created_at %>
+  <% t.column :created_at, 'Created At' %>
   <% t.column 'Currency' do |x| %>
     <%= x.currency.code.upcase %>
   <% end %>
@@ -15,10 +15,10 @@
   <% t.column 'Withdraw Address' do |x| %>
     <a href="<%= x.wallet_url %>" target="_blank" ><%= x.rid.truncate(22) %></a>
   <% end %>
-  <% t.column :amount do |x| %>
+  <% t.column 'Amount' do |x| %>
     <code class="text-info"><%= x.amount %></code>
   <% end %>
-  <% t.column :state_and_action do |x| %>
+  <% t.column 'State/Actions' do |x| %>
     <span><%= x.aasm_state.humanize %> | </span>
     <% if can? :write, Withdraw %>
       <span><%= link_to 'Process',

--- a/app/views/admin/withdraws/coins/_table.html.erb
+++ b/app/views/admin/withdraws/coins/_table.html.erb
@@ -1,11 +1,11 @@
 <%= table_for withdraws, class: 'table table-bordered table-striped', model: Withdraws::Coin do |t| %>
-  <% t.column :id %>
-  <% t.column :txid do |x| %>
+  <% t.column :id, 'Withdrawal ID' %>
+  <% t.column 'TXID' do |x| %>
     <a href="<%= x.transaction_url %>" target="_blank">
       <code class="text-info"><%= x.txid%></code>
     </a>
   <% end %>
-  <% t.column :created_at %>
+  <% t.column :created_at, 'Created At' %>
   <% t.column 'Currency' do |x| %>
     <%= x.currency.code.upcase %>
   <% end %>
@@ -15,10 +15,10 @@
   <% t.column 'Withdraw Address' do |x| %>
     <a href="<%= x.wallet_url %>" target="_blank" ><%= x.rid.truncate(22) %></a>
   <% end %>
-  <% t.column :amount do |x| %>
+  <% t.column 'Amount' do |x| %>
     <code class="text-info"><%= x.amount %></code>
   <% end %>
-  <% t.column :state_and_action do |x| %>
+  <% t.column 'State/Action' do |x| %>
     <span><%= x.aasm_state.humanize %> / </span>
     <%= link_to 'View', admin_withdraw_path(currency: x.currency.code, id: x) %>
   <% end %>

--- a/app/views/admin/withdraws/coins/index.html.erb
+++ b/app/views/admin/withdraws/coins/index.html.erb
@@ -1,13 +1,13 @@
 <% if can? :read, Withdraw %>
   <div class="row">
     <div class="col-6">
-    <%= link_to raw("All withdraws"), admin_withdraw_index_path(state: 'all'), class: 'btn btn-primary  mb-3' %>
-    <%= link_to raw("Latest withdraws"), admin_withdraw_index_path(state: 'latest'), class: 'btn btn-primary  mb-3' %>
-    <%= link_to raw("Pending withdraws"), admin_withdraw_index_path(state: 'pending'), class: 'btn btn-primary  mb-3' %>
+    <%= link_to raw("All withdrawals"), admin_withdraw_index_path(state: 'all'), class: 'btn btn-primary  mb-3' %>
+    <%= link_to raw("Latest withdrawals"), admin_withdraw_index_path(state: 'latest'), class: 'btn btn-primary  mb-3' %>
+    <%= link_to raw("Pending withdrawals"), admin_withdraw_index_path(state: 'pending'), class: 'btn btn-primary  mb-3' %>
     </div>
   </div>
   <% if @latest_withdraws %>
-    <h3>Withdraws for the last 24 hours</h3>
+    <h3>Withdrawals for the last 24 hours</h3>
     <div class="card">
       <%= render partial: 'table', locals: {withdraws: @latest_withdraws} %>
     </div>
@@ -17,7 +17,7 @@
   <% end %>
   <% if @all_withdraws %>
     <div class="col-6">
-      <h3>All withdraws</h3>
+      <h3>All withdrawals</h3>
     </div>
     <div class="card">
       <%= render partial: 'table', locals: {withdraws: @all_withdraws} %>
@@ -28,7 +28,7 @@
   <% end %>
   <% if @pending_withdraws %>
     <div class="col-6">
-      <h3>Pending withdraws</h3>
+      <h3>Pending withdrawals</h3>
     </div>
     <div class="card">
       <%= render partial: 'pending_table', locals: {withdraws: @pending_withdraws} %>

--- a/app/views/admin/withdraws/coins/show.html.erb
+++ b/app/views/admin/withdraws/coins/show.html.erb
@@ -3,7 +3,7 @@
 
     <div class="card card-primary">
       <div class="card-header">
-        <span>Withdraw</span>
+        <span>Withdrawal</span>
       </div>
       <div class="card-body">
         <%= description_for :withdraw do %>

--- a/app/views/admin/withdraws/fiats/_table.html.erb
+++ b/app/views/admin/withdraws/fiats/_table.html.erb
@@ -1,6 +1,6 @@
 <%= table_for withdraws, class: 'table table-bordered table-striped', model: Withdraws::Fiat do |t| %>
-  <% t.column :id %>
-  <% t.column :created_at %>
+  <% t.column :id, 'Withdrawal ID' %>
+  <% t.column :created_at, 'Created At' %>
   <% t.column 'Currency' do |x| %>
     <% x.currency.code.upcase %>
   <% end %>
@@ -10,12 +10,12 @@
   <% t.column 'Recipient ID' do |x| %>
     <span><%= x.rid %></span>
   <% end %>
-  <% t.column :amount do |x| %>
+  <% t.column 'Amount' do |x| %>
     <code class="text-info">
       <%= x.amount %>
     </code>
   <% end %>
-  <% t.column :state_and_action do |x| %>
+  <% t.column 'State/Action' do |x| %>
     <span><%= x.aasm_state.humanize %> / </span>
     <%= link_to 'View', admin_withdraw_path(currency: x.currency.code, id: x) %>
   <% end %>

--- a/app/views/admin/withdraws/fiats/index.html.erb
+++ b/app/views/admin/withdraws/fiats/index.html.erb
@@ -1,12 +1,12 @@
 <% if can? :read, Withdraw %>
   <div class="row">
     <div class="col-6">
-      <%= link_to raw("All withdraws"), admin_withdraw_index_path(state: 'all'), class: 'btn btn-primary  mb-3' %>
-      <%= link_to raw("Latest withdraws"), admin_withdraw_index_path(state: 'latest'), class: 'btn btn-primary  mb-3' %>
+      <%= link_to raw("All withdrawals"), admin_withdraw_index_path(state: 'all'), class: 'btn btn-primary  mb-3' %>
+      <%= link_to raw("Latest withdrawals"), admin_withdraw_index_path(state: 'latest'), class: 'btn btn-primary  mb-3' %>
     </div>
   </div>
   <% if @latest_withdraws %>
-    <h3>Withdraws for the last 24 hours</h3>
+    <h3>Withdrawals for the last 24 hours</h3>
     <div class="card">
       <%= render partial: 'table', locals: {withdraws: @latest_withdraws} %>
     </div>
@@ -16,7 +16,7 @@
   <% end %>
   <% if @all_withdraws %>
     <div class="col-6">
-      <h3>All withdraws</h3>
+      <h3>All withdrawals</h3>
     </div>
     <div class="card">
       <%= render partial: 'table', locals: {withdraws: @all_withdraws} %>

--- a/spec/controllers/admin/markets_controller_spec.rb
+++ b/spec/controllers/admin/markets_controller_spec.rb
@@ -5,16 +5,16 @@ describe Admin::MarketsController, type: :controller do
   let(:member) { create(:admin_member) }
   before(:each) { inject_authorization!(member) }
   let :attributes do
-    { quote_unit:         'usd',
-      bid_fee:          '0.003'.to_d,
-      price_precision:  4,
-      base_unit:         'eth',
-      ask_fee:          '0.02'.to_d,
-      min_amount:       '0.02'.to_d,
-      min_price:        '0.02'.to_d,
-      amount_precision: 4,
-      state:            'enabled',
-      position:         100 }
+    { quote_currency:     'usd',
+      base_currency_fee:  '0.003'.to_d,
+      price_precision:    4,
+      base_currency:      'eth',
+      quote_currency_fee: '0.02'.to_d,
+      min_amount:         '0.02'.to_d,
+      min_price:          '0.02'.to_d,
+      amount_precision:   4,
+      state:              'enabled',
+      position:           100 }
   end
   let(:existing_market) { Market.ordered.first }
 
@@ -32,7 +32,7 @@ describe Admin::MarketsController, type: :controller do
 
     it 'doesn\'t create market if commodity pair already exists' do
       existing = Market.ordered.first
-      params   = attributes.merge(quote_unit: existing.quote_unit, base_unit: existing.base_unit)
+      params   = attributes.merge(quote_currency: existing.quote_currency, base_currency: existing.base_currency)
       expect do
         post :create, params: { trading_pair: params }
         expect(response).not_to redirect_to admin_markets_path
@@ -42,10 +42,10 @@ describe Admin::MarketsController, type: :controller do
 
   describe '#update' do
     let :new_attributes do
-      { quote_unit:         'btc',
+      { quote_currency:         'btc',
         bid_fee:          '0.002'.to_d,
         price_precision:    7,
-        base_unit:         'eth',
+        base_currency:         'eth',
         ask_fee:          '0.05'.to_d,
         min_amount:       '0.02'.to_d,
         amount_precision: 7,
@@ -56,8 +56,8 @@ describe Admin::MarketsController, type: :controller do
     let :final_attributes do
       new_attributes.merge \
         attributes.slice \
-          :quote_unit,
-          :base_unit,
+          :quote_currency,
+          :base_currency,
           :amount_precision,
           :price_precision
     end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -13,12 +13,14 @@ describe Market do
       expect(subject.name).to eq 'BTC/USD'
     end
 
-    it 'base_unit' do
+    it 'base_currency' do
       expect(subject.base_unit).to eq 'btc'
+      expect(subject.base_currency).to eq 'btc'
     end
 
-    it 'quote_unit' do
+    it 'quote_currency' do
       expect(subject.quote_unit).to eq 'usd'
+      expect(subject.quote_currency).to eq 'usd'
     end
 
     it 'state' do
@@ -57,27 +59,27 @@ describe Market do
 
   context 'validations' do
     let(:valid_attributes) do
-      { base_unit:         :btc,
-        quote_unit:         :trst,
-        bid_fee:          0.1,
-        ask_fee:          0.2,
-        min_amount:       0.0001,
-        min_price:        0.0001,
-        amount_precision: 4,
-        price_precision:  4,
-        position:         100 }
+      { base_currency:      :btc,
+        quote_currency:     :trst,
+        base_currency_fee:  0.1,
+        quote_currency_fee: 0.2,
+        min_amount:         0.0001,
+        min_price:          0.0001,
+        amount_precision:   4,
+        price_precision:    4,
+        position:           100 }
     end
 
     let(:mirror_attributes) do
-      { base_unit:         :usd,
-        quote_unit:         :btc,
-        bid_fee:          0.1,
-        ask_fee:          0.2,
-        min_amount:       0.0001,
-        min_price:        0.0001,
-        amount_precision: 4,
-        price_precision:  4,
-        position:         100 }
+      { base_currency:      :usd,
+        quote_currency:     :btc,
+        base_currency_fee:  0.1,
+        quote_currency_fee: 0.2,
+        min_amount:         0.0001,
+        min_price:          0.0001,
+        amount_precision:   4,
+        price_precision:    4,
+        position:           100 }
     end
 
     let(:disabled_currency) { Currency.find_by_id(:eur) }
@@ -88,26 +90,26 @@ describe Market do
       expect(record.save).to eq true
     end
 
-    it 'validates equivalence of units' do
-      record = Market.new(valid_attributes.merge(quote_unit: valid_attributes[:base_unit]))
+    it 'validates quote currency duplication' do
+      record = Market.new(valid_attributes.merge(quote_currency: valid_attributes[:base_currency]))
       record.save
-      expect(record.errors.full_messages).to include(/base unit is invalid/i)
+      expect(record.errors.full_messages).to include(/quote currency duplicates base currency/i)
     end
 
-    it 'validates uniqueness of ID' do
+    it 'validates same market' do
       record = build(:market, :btcusd)
       record.save
-      expect(record.errors.full_messages).to include(/id has already been taken/i)
+      expect(record.errors.full_messages).to include(/market already exists/i)
     end
 
     it 'validates mirror market pair' do
       record = Market.new(mirror_attributes)
       record.save
-      expect(record.errors.full_messages).to include(/id has already been taken/i)
+      expect(record.errors.full_messages).to include(/market already exists/i)
     end
 
-    it 'validates presence of units' do
-      %i[base_unit quote_unit].each do |field|
+    it 'validates presence of currencies' do
+      %i[base_currency quote_currency].each do |field|
         record = Market.new(valid_attributes.except(field))
         record.save
         expect(record.errors.full_messages).to include(/#{to_readable(field)} can't be blank/i)
@@ -115,7 +117,8 @@ describe Market do
     end
 
     it 'validates fields to be greater than or equal to 0' do
-      %i[bid_fee ask_fee price_precision amount_precision position].each do |field|
+      %i[base_currency_fee quote_currency_fee
+         price_precision amount_precision position].each do |field|
         record = Market.new(valid_attributes.merge(field => -1))
         record.save
         expect(record.errors.full_messages).to include(/#{to_readable(field)} must be greater than or equal to 0/i)
@@ -130,8 +133,8 @@ describe Market do
       end
     end
 
-    it 'validates unit codes to be inclusion of currency codes' do
-      %i[base_unit quote_unit].each do |field|
+    it 'validates currencies codes to be inclusion of currency codes' do
+      %i[base_currency quote_currency].each do |field|
         record = Market.new(valid_attributes.merge(field => :bad))
         record.save
         expect(record.errors.full_messages).to include(/#{to_readable(field)} is not included in the list/i)
@@ -139,7 +142,7 @@ describe Market do
     end
 
     it 'validates if both currencies enabled on enabled market creation' do
-      %i[base_unit quote_unit].each do |field|
+      %i[base_currency quote_currency].each do |field|
         record = Market.new(valid_attributes.merge(field => disabled_currency.code))
         record.save
         expect(record.errors.full_messages).to include(/#{to_readable(field)} is not enabled/i)
@@ -147,7 +150,7 @@ describe Market do
     end
 
     it 'doesn\'t validate if both currencies enabled on disabled market creation' do
-      %i[base_unit quote_unit].each do |field|
+      %i[base_currency quote_currency].each do |field|
         record = Market.new(valid_attributes.merge(field => disabled_currency.code, state: 'disabled'))
         expect(record.save).to eq true
       end


### PR DESCRIPTION
- Improve Market form validations and errors
  - Ask/Bid fee -> Quote/Base currency fee
  - Base/Quote unit -> Base/Quote currency
  - Use number_field for decimals
  - Id has already been taken -> #{base}, #{quote} market already exists
  - Validate amount_precision instead of precisions sum
  - Validate price_preciosion to be less than FUNDS_PRECISION
  - Validate amount_precision to be less than FUNDS_PRECISION - price_precision
- Update deposit table columns
- Validate code instead of id in Currency
- Define convention for organizing Ruby On Rails Models
- Use 'withdrawal' instead of 'withdraw' everywhere