### PR TITLE
Fix double spending issue on withdraw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,6 @@ env:
     BOT_EMAIL=kite-bot@heliostech.fr
     BULLET="true"
 
-services:
-  - mysql
-  - redis-server
-  - rabbitmq
-  - docker
-  - docker-compose
-
 # Execute all of the commands which need to be executed before installing dependencies.
 before_install:
   - gem install bundler -v 1.17.3
@@ -29,8 +22,11 @@ before_install:
 
 # Execute all of the commands which should install application dependencies.
 install:
-  - docker-compose -f config/backend.yml up -d vault
+  - sudo service mysql stop
+  - docker-compose -f config/backend.yml up -d vault db rabbitmq redis
   - bundle install --deployment --without production --jobs=$(nproc) --retry=3
+  # Wait for backend services.
+  - sleep 10
 
 # Execute all of the commands which need to be executed before running actual tests.
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Merged pull requests:**
 
 - Remove withdrawal attempts [\#2281](https://github.com/rubykube/peatio/pull/2281) ([mnaichuk](https://github.com/mnaichuk))
+- Remove withdrawal attempts [\#2280](https://github.com/rubykube/peatio/pull/2280) ([mnaichuk](https://github.com/mnaichuk))
 - Multi coin support for altcoins [\#2243](https://github.com/rubykube/peatio/pull/2243) ([Xicy](https://github.com/Xicy))
 - Fix GET /withdraws to include both fiat and crypto  [\#2222](https://github.com/rubykube/peatio/pull/2222) ([msembinelli](https://github.com/msembinelli))
 

--- a/app/controllers/admin/withdraws/coins_controller.rb
+++ b/app/controllers/admin/withdraws/coins_controller.rb
@@ -27,6 +27,11 @@ module Admin
           process!
         when 'load'
           load!
+        when 'approve'
+          approve!
+        when 'fail'
+          @withdraw.fail!
+          redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated'
         end
       end
 
@@ -50,9 +55,17 @@ module Admin
         redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated.'
       end
 
+      def approve!
+        @withdraw.transaction do
+          @withdraw.update!(txid: params[:txid]) if params[:txid].present?
+          @withdraw.success!
+        end
+        redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated.'
+      end
+
       def load!
         @withdraw.transaction do
-          @withdraw.update!(txid: params.fetch(:txid))
+          @withdraw.update!(txid: params[:txid]) if params[:txid].present?
           @withdraw.load!
         end
         redirect_to admin_withdraw_path(currency.id, @withdraw.id), notice: 'Withdrawal succesfully updated.'

--- a/app/models/withdraws/coin.rb
+++ b/app/models/withdraws/coin.rb
@@ -50,7 +50,7 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190723202251
+# Schema version: 20190725131843
 #
 # Table name: withdraws
 #
@@ -68,6 +68,7 @@ end
 #  tid          :string(64)       not null
 #  rid          :string(95)       not null
 #  note         :string(256)
+#  error        :json
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  completed_at :datetime

--- a/app/models/withdraws/fiat.rb
+++ b/app/models/withdraws/fiat.rb
@@ -8,7 +8,7 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190723202251
+# Schema version: 20190725131843
 #
 # Table name: withdraws
 #
@@ -26,6 +26,7 @@ end
 #  tid          :string(64)       not null
 #  rid          :string(95)       not null
 #  note         :string(256)
+#  error        :json
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  completed_at :datetime

--- a/app/views/admin/withdraws/coins/show.html.erb
+++ b/app/views/admin/withdraws/coins/show.html.erb
@@ -27,14 +27,30 @@
             <span><%= @withdraw.rid %></span>
           <% end %>
           <%= item_for @withdraw, :amount %>
+          <%= item_for @withdraw, 'Errors' do %>
+            <% @withdraw.error&.each do |error| %>
+              <%= item_for :Class, error['class'] %>
+              <%= item_for :Message, error['message'] %>
+            <% end %>
+          <% end %>
           <hr>
-          <% if (can? :manage, Withdraw) && (@withdraw.may_accept? || @withdraw.may_process? || @withdraw.confirming?) %>
+          <% if (can? :write, Withdraw) && !@withdraw.errored? && (@withdraw.may_accept? || @withdraw.may_process? || @withdraw.confirming?) %>
             <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
               <%= form_tag admin_withdraw_path(event: 'load'), method: 'PATCH' do -%>
                 <%= text_field_tag :txid, nil, placeholder: 'Set txid here...', class: 'form-control w-50 d-inline ml-4' %>
-                <%= submit_tag 'Load withdraw', class: 'btn btn-primary float-left' %>
+                <%= submit_tag 'Load withdrawal', class: 'btn btn-primary float-left' %>
               <% end -%>
             </ul>
+          <% end %>
+          <% if (can? :write, Withdraw) && @withdraw.errored? %>
+              <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
+                <%= form_tag admin_withdraw_path(event: 'approve'), method: 'PATCH' do -%>
+                  <% if @withdraw.txid.blank? %>
+                    <%= text_field_tag :txid, nil, placeholder: 'Set txid here...', class: 'form-control w-50 d-inline ml-4' %>
+                  <% end %>
+                  <%= submit_tag 'Approve withdrawal', class: 'btn btn-primary float-left' %>
+                <% end -%>
+              </ul>
           <% end %>
           <ul class="list-inline w-100 px-3 mt-3 pt-3 border-top">
             <% if can? :write, Withdraw %>
@@ -51,6 +67,14 @@
                   <%= link_to 'Process',
                               admin_withdraw_path(event: 'process'),
                               class: 'btn btn-primary float-left',
+                              method: 'PATCH' %>
+                </li>
+              <% end %>
+              <% if @withdraw.errored? && @withdraw.may_fail? %>
+                <li>
+                  <%= link_to 'Fail',
+                              admin_withdraw_path(event: 'fail'),
+                              class:   'btn btn-danger float-right',
                               method: 'PATCH' %>
                 </li>
               <% end %>

--- a/app/workers/amqp/withdraw_coin.rb
+++ b/app/workers/amqp/withdraw_coin.rb
@@ -77,19 +77,14 @@ module Workers
           withdraw.dispatch
           withdraw.save!
 
-          @logger.warn id: withdraw.id, message: 'OK.'
+          @logger.warn id: withdraw.id, message: 'Withdrawal has processed'
 
-        rescue Exception => e
-          begin
-            @logger.error id: withdraw.id,
-                          message: 'Failed to process withdraw. See exception details below.'
-            report_exception(e)
-            @logger.warn id: withdraw.id,
-                         message: 'Setting withdraw state to failed.'
-          ensure
-            withdraw.fail!
-            @logger.warn id: withdraw.id, message: 'OK.'
-          end
+        rescue StandardError => e
+          @logger.warn id: withdraw.id, message: 'Failed to process withdrawal. See exception details below.'
+          report_exception(e)
+          withdraw.err! e
+          @logger.warn id: withdraw.id,
+                       message: 'Setting withdrawal state to errored.'
         end
       end
     end

--- a/db/migrate/20190725131843_add_error_to_withdraw.rb
+++ b/db/migrate/20190725131843_add_error_to_withdraw.rb
@@ -1,0 +1,5 @@
+class AddErrorToWithdraw < ActiveRecord::Migration[5.2]
+  def change
+    add_column :withdraws, :error, :json, after: :note
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_202251) do
+ActiveRecord::Schema.define(version: 2019_07_25_131843) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "member_id", null: false
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 2019_07_23_202251) do
     t.string "tid", limit: 64, null: false, collation: "utf8_bin"
     t.string "rid", limit: 95, null: false
     t.string "note", limit: 256
+    t.json "error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "completed_at"

--- a/docs/releases/2.2.0.md
+++ b/docs/releases/2.2.0.md
@@ -128,4 +128,5 @@ This release notes is must-read for migrating from older versions.
 - Fix bin/gendocs [\#2272](https://github.com/rubykube/peatio/pull/2272) ([mnaichuk](https://github.com/mnaichuk))
 - Fix issue with rake task release.rake in travis [\#2275](https://github.com/rubykube/peatio/pull/2275) ([mnaichuk](https://github.com/mnaichuk))
 - Fix GET /withdraws to include both fiat and crypto  [\#2222](https://github.com/rubykube/peatio/pull/2222) ([msembinelli](https://github.com/msembinelli))
+- Remove withdrawal attempts [\#2280](https://github.com/rubykube/peatio/pull/2280) ([mnaichuk](https://github.com/mnaichuk))
 - Remove withdrawal attempts [\#2281](https://github.com/rubykube/peatio/pull/2281) ([mnaichuk](https://github.com/mnaichuk))

--- a/lib/peatio/bitcoin/client.rb
+++ b/lib/peatio/bitcoin/client.rb
@@ -1,24 +1,20 @@
 module Bitcoin
   class Client
     Error = Class.new(StandardError)
-    class ConnectionError < Error;
-    end
+
+    class ConnectionError < Error; end
 
     class ResponseError < Error
       def initialize(code, msg)
-        @code = code
-        @msg = msg
-      end
-
-      def message
-        "#{@msg} (#{@code})"
+        super "#{msg} (#{code})"
       end
     end
 
     extend Memoist
 
-    def initialize(endpoint)
+    def initialize(endpoint, idle_timeout: 5)
       @json_rpc_endpoint = URI.parse(endpoint)
+      @idle_timeout = idle_timeout
     end
 
     def json_rpc(method, params = [])
@@ -29,23 +25,19 @@ module Bitcoin
          'Content-Type' => 'application/json'}
       response.assert_success!
       response = JSON.parse(response.body)
-      response['error'].tap {|error| raise ResponseError.new(error['code'], error['message']) if error}
+      response['error'].tap { |error| raise ResponseError.new(error['code'], error['message']) if error }
       response.fetch('result')
-    rescue => e
-      if e.is_a?(Error)
-        raise e
-      elsif e.is_a?(Faraday::Error)
-        raise ConnectionError, e
-      else
-        raise Error, e
-      end
+    rescue Faraday::Error => e
+      raise ConnectionError, e
+    rescue StandardError => e
+      raise Error, e
     end
 
     private
 
     def connection
       @connection ||= Faraday.new(@json_rpc_endpoint) do |f|
-        f.adapter :net_http_persistent, pool_size: 5
+        f.adapter :net_http_persistent, pool_size: 5, idle_timeout: @idle_timeout
       end.tap do |connection|
         unless @json_rpc_endpoint.user.blank?
           connection.basic_auth(@json_rpc_endpoint.user, @json_rpc_endpoint.password)

--- a/lib/peatio/bitcoin/wallet.rb
+++ b/lib/peatio/bitcoin/wallet.rb
@@ -52,7 +52,7 @@ module Bitcoin
 
     def client
       uri = @wallet.fetch(:uri) { raise Peatio::Wallet::MissingSettingError, :uri }
-      @client ||= Client.new(uri)
+      @client ||= Client.new(uri, idle_timeout: 1)
     end
   end
 end

--- a/lib/peatio/ethereum/client.rb
+++ b/lib/peatio/ethereum/client.rb
@@ -1,25 +1,21 @@
 module Ethereum
   class Client
     Error = Class.new(StandardError)
-    class ConnectionError < Error;
-    end
+
+    class ConnectionError < Error; end
 
     class ResponseError < Error
       def initialize(code, msg)
-        @code = code
-        @msg = msg
-      end
-
-      def message
-        "#{@msg} (#{@code})"
+        super "#{msg} (#{code})"
       end
     end
 
     extend Memoist
 
-    def initialize(endpoint)
+    def initialize(endpoint, idle_timeout: 5)
       @json_rpc_endpoint = URI.parse(endpoint)
       @json_rpc_call_id = 0
+      @idle_timeout = idle_timeout
     end
 
     def json_rpc(method, params = [])
@@ -30,16 +26,12 @@ module Ethereum
            'Content-Type' => 'application/json'}
       response.assert_success!
       response = JSON.parse(response.body)
-      response['error'].tap {|error| raise ResponseError.new(error['code'], error['message']) if error}
+      response['error'].tap { |error| raise ResponseError.new(error['code'], error['message']) if error }
       response.fetch('result')
-    rescue => e
-      if e.is_a?(Error)
-        raise e
-      elsif e.is_a?(Faraday::Error)
-        raise ConnectionError, e
-      else
-        raise Error, e
-      end
+    rescue Faraday::Error => e
+      raise ConnectionError, e
+    rescue StandardError => e
+      raise Error, e
     end
 
     private
@@ -50,7 +42,7 @@ module Ethereum
 
     def connection
       @connection ||= Faraday.new(@json_rpc_endpoint) do |f|
-        f.adapter :net_http_persistent, pool_size: 5
+        f.adapter :net_http_persistent, pool_size: 5, idle_timeout: @idle_timeout
       end.tap do |connection|
         unless @json_rpc_endpoint.user.blank?
           connection.basic_auth(@json_rpc_endpoint.user, @json_rpc_endpoint.password)

--- a/lib/peatio/ethereum/wallet.rb
+++ b/lib/peatio/ethereum/wallet.rb
@@ -175,7 +175,7 @@ module Ethereum
 
     def client
       uri = @wallet.fetch(:uri) { raise Peatio::Wallet::MissingSettingError, :uri }
-      @client ||= Client.new(uri)
+      @client ||= Client.new(uri, idle_timeout: 1)
     end
   end
 end

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -211,6 +211,17 @@ describe Withdraw do
         subject.process!
         expect(subject.processing?).to be true
       end
+
+      it 'transitions to :errored after calling #err from :processing' do
+        subject.process!
+        expect(subject.processing?).to be true
+
+        expect { subject.err! StandardError.new }.to_not change { subject.account.amount }
+        expect(subject.errored?).to be true
+
+        subject.process!
+        expect(subject.processing?).to be true
+      end
     end
 
     context :cancel do


### PR DESCRIPTION
- Fix issue with `too many connection resets` by specifying `idle_timeout=1s`.
- Add new state for withdraw: `errored`. 
- Add admin ability to approve or fail withdrawal with state `errored`. 
- Start db, rabbitmq and redis with docker-compose inside travis.  

Errored state means that admin should manually check, if blockchain transaction was created or not.

Co-authored-by: mnaichuk <mnaichuk@heliostech.fr>
Co-authored-by: shal <ashanaakh@heliostech.fr>