### PR TITLE
Change run Peatio::Application to Rails.application in config.ru

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -15,5 +15,5 @@ map Rails.application.config.relative_url_root do
         max_age: CORS::Validations.validate_max_age(ENV['API_CORS_MAX_AGE'])
     end
   end
-  run Peatio::Application
+  run Rails.application
 end


### PR DESCRIPTION
Using `Rails::Application` subclass to start the server is deprecated
and was removed in Rails 6.0.

https://github.com/rails/rails/commit/553b86fc751c751db504bcbe2d033eb2bb5b6a0b