### PR TITLE
Trading Fee Schedule based on Member group

### DIFF
--- a/app/api/v2/admin/markets.rb
+++ b/app/api/v2/admin/markets.rb
@@ -10,18 +10,6 @@ module API
           # Collection of shared params, used to
           # generate required/optional Grape params.
           OPTIONAL_MARKET_PARAMS = {
-            maker_fee: {
-              type: { value: BigDecimal, message: 'admin.market.non_decimal_maker_fee' },
-              values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_maker_fee' },
-              default: 0.0,
-              desc: -> { API::V2::Admin::Entities::Market.documentation[:maker_fee][:desc] }
-            },
-            taker_fee: {
-              type: { value: BigDecimal, message: 'admin.market.non_decimal_bid_fee' },
-              values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_bid_fee' },
-              default: 0.0,
-              desc: -> { API::V2::Admin::Entities::Market.documentation[:taker_fee][:desc] }
-            },
             max_price: {
               type: { value: BigDecimal, message: 'admin.market.non_decimal_max_price' },
               values: { value: -> (p){ p >= 0 }, message: 'admin.market.invalid_max_price' },

--- a/app/api/v2/entities/market.rb
+++ b/app/api/v2/entities/market.rb
@@ -41,22 +41,6 @@ module API
         )
 
         expose(
-          :maker_fee,
-          documentation: {
-            type: BigDecimal,
-            desc: "Market maker fee."
-          }
-        )
-
-        expose(
-          :taker_fee,
-          documentation: {
-            type: BigDecimal,
-            desc: "Market taker fee."
-          }
-        )
-
-        expose(
           :min_price,
           documentation: {
             type: BigDecimal,

--- a/app/api/v2/management/entities/member.rb
+++ b/app/api/v2/management/entities/member.rb
@@ -1,0 +1,66 @@
+module API
+  module V2
+    module Management
+      module Entities
+        class Member < Base
+          expose(
+            :uid,
+            documentation: {
+              type: String,
+              desc: 'The shared user ID.'
+            }
+          )
+
+          expose(
+            :email,
+            documentation: {
+              type: String,
+              desc: 'User email.'
+            }
+          )
+
+          expose(
+            :level,
+            documentation: {
+              type: Integer,
+              desc: 'User level.'
+            }
+          )
+
+          expose(
+            :role,
+            documentation: {
+              type: String,
+              desc: 'User role.'
+            }
+          )
+
+          expose(
+            :group,
+            documentation: {
+              type: String,
+              desc: 'User group (vip-0, vip-1, etc).'
+            }
+          )
+
+          expose(
+            :state,
+            documentation: {
+              type: String,
+              desc: 'User state (active/pending/banned).'
+            }
+          )
+
+          expose(
+            :created_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'User create time in iso8601 format.'
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/management/members.rb
+++ b/app/api/v2/management/members.rb
@@ -1,0 +1,31 @@
+module API
+  module V2
+    module Management
+      class Members < Grape::API
+
+        desc 'Set user group.' do
+          @settings[:scope] = :write_members
+        end
+        params do
+          requires :uid,
+                   type: String,
+                   desc: 'The shared user ID.'
+          requires :group,
+                   type: String,
+                   desc: 'User gruop'
+        end
+        post '/members/group' do
+          declared_params = declared(params)
+
+          member = Member.find_by!(uid: declared_params[:uid])
+          member.update!(group: declared_params[:group])
+          present member, with: Entities::Member
+          status 200
+        rescue ActiveRecord::RecordInvalid => e
+          body errors: e.message
+          status 422
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/management/mount.rb
+++ b/app/api/v2/management/mount.rb
@@ -42,6 +42,7 @@ module API
         mount Management::Operations
         mount Management::Transfers
         mount Management::Trades
+        mount Management::Members
 
         # The documentation is accessible at http://localhost:3000/swagger?url=/api/v2/management/swagger
         # Add swagger documentation for Peatio Management API

--- a/app/controllers/admin/markets_controller.rb
+++ b/app/controllers/admin/markets_controller.rb
@@ -47,8 +47,6 @@ module Admin
       attributes = %i[
         base_currency
         quote_currency
-        maker_fee
-        taker_fee
         state
         min_price
         max_price

--- a/app/models/concerns/precision_validator.rb
+++ b/app/models/concerns/precision_validator.rb
@@ -1,0 +1,23 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+class PrecisionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless options.key?(:less_than_or_eq_to) && value.present?
+
+    precision = if options[:less_than_or_eq_to].respond_to?(:call)
+                  options[:less_than_or_eq_to].call(record)
+                else
+                  options[:less_than_or_eq_to]
+                end
+
+    unless value.is_a?(Numeric)
+      record.errors.add(attribute, 'must be a number')
+      return
+    end
+
+    unless value.round(precision) == value
+      record.errors.add(attribute, "precision must be less than or equal to #{precision}")
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -160,7 +160,7 @@ private
 end
 
 # == Schema Information
-# Schema version: 20181027192001
+# Schema version: 20190816125948
 #
 # Table name: members
 #
@@ -169,6 +169,7 @@ end
 #  email      :string(255)      not null
 #  level      :integer          not null
 #  role       :string(16)       not null
+#  group      :string(32)       default("vip-0"), not null
 #  state      :string(16)       not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/trading_fee.rb
+++ b/app/models/trading_fee.rb
@@ -1,0 +1,136 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+# A trading fee schedule is a complete listing of maker and taker fees.
+#
+# E.g
+# +-----------+---------+---------+---------+---------------------+---------------------+
+# | market_id |  group  |  maker  |  taker  |     created_at      |      updated_at     |
+# +-----------+---------+---------+---------+---------------------+---------------------+
+# |   any     | any     | 0.0012  | 0.0012  | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# |   any     | vip-0   | 0.0011  | 0.0011  | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# | btcusd    | any     | 0.0011  | 0.0011  | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# | btcusd    | vip-0   | 0.001   | 0.001   | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# | btcusd    | vip-1   | 0.0009  | 0.001   | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# | btcusd    | vip-2   | 0.0007  | 0.0009  | 2019-07-31 13:41:00 | 2019-07-31 13:41:00 |
+# +-----------+---------+---------+---------+---------------------+---------------------+
+#
+# for member with unspecified group and market
+#   maker fee will be 0.12%;
+#   taker fee will be 0.12%;
+# for member with group vip-0 and with unspecified market
+#   maker fee will be 0.11%;
+#   taker fee will be 0.11%;
+# for member with market btcusd and with unspecified group
+#   maker fee will be 0.11%;
+#   taker fee will be 0.11%;
+# for member with group vip-0 and for market btcusd
+#   maker fee will be 0.1%;
+#   taker fee will be 0.1%;
+# for member with group vip-1 and for market btcusd
+#   maker fee will be 0.09%;
+#   taker fee will be 0.1%;
+# for member with group vip-2 and for market btcusd
+#   maker fee will be 0.07%;
+#   taker fee will be 0.09%;
+#
+class TradingFee < ApplicationRecord
+  # == Constants ============================================================
+
+  # For fee we define static precision - 4.
+  FEE_PRECISION = 4
+
+  MIN_FEE = 0
+  MAX_FEE = 0.5
+
+  # Default value for group name and market_id in TradingFee table;
+  ANY = 'any'
+
+  # == Attributes ===========================================================
+
+  # == Extensions ===========================================================
+
+  # == Relationships ========================================================
+
+  belongs_to :market, optional: true
+
+  # == Validations ==========================================================
+
+  validates :group, uniqueness: { scope: :market_id }
+
+  validates :maker,
+            :taker,
+            presence: true,
+            numericality: { greater_than_or_equal_to: MIN_FEE,
+                            less_than_or_equal_to: MAX_FEE }
+
+  validates :market_id,
+            inclusion: { in: ->(_fs){ Market.ids.push(ANY) } },
+            if: ->(fs){ fs.market_id.present? }
+
+  validates :maker, :taker, precision: { less_than_or_eq_to: FEE_PRECISION }
+
+  # == Scopes ===============================================================
+
+  # == Callbacks ============================================================
+
+  # == Class Methods ========================================================
+
+  class << self
+
+    # Get trading fee schedule for specific order that based on member group and market_id.
+    # TradingFee record selected with the next priorities:
+    #  1. both group and market_id match
+    #  2. group match
+    #  3. market_id match
+    #  4. both group and market_id are nil
+    #  5. default (zero fees)
+    def for(group:, market_id:)
+      TradingFee
+        .where(market_id: [market_id, ANY], group: [group, ANY])
+        .max_by { |fs| fs.weight } || TradingFee.new
+    end
+  end
+
+  # == Instance Methods =====================================================
+
+  # Filter to get the most suitable trading fee schedule
+  # Method defines weight of trading_fee record in fee schedule.
+  # Group match has greater weight then market_id.
+  # E.g. Order for member with group 'vip-0' and market_id 'btcusd'
+  # (group == 'vip-0' && market_id == 'btcusd') >
+  # (group == 'vip-0' && market_id == 'any') >
+  # (group == 'any' && market_id == 'btcusd') >
+  # (group == 'any' && market_id == 'any')
+  def weight
+    (group.any? ? 0 : 10) + (market_id.any? ? 0 : 1)
+  end
+
+  def group
+    super&.inquiry
+  end
+
+  def market_id
+    super&.inquiry
+  end
+end
+
+# == Schema Information
+# Schema version: 20190816125948
+#
+# Table name: trading_fees
+#
+#  id         :bigint           not null, primary key
+#  market_id  :string(20)       default("any"), not null
+#  group      :string(32)       default("any"), not null
+#  maker      :decimal(5, 4)    default(0.0), not null
+#  taker      :decimal(5, 4)    default(0.0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_trading_fees_on_group                (group)
+#  index_trading_fees_on_market_id            (market_id)
+#  index_trading_fees_on_market_id_and_group  (market_id,group) UNIQUE
+#

--- a/config/templates/management_api_v1.yml.erb
+++ b/config/templates/management_api_v1.yml.erb
@@ -62,6 +62,7 @@ jwt: {}
 #   – write_operations
 #   – read_transfers
 #   – write_transfers
+#   – write_members
 #   – tools
 #
 scopes: {}

--- a/config/templates/seed/markets.yml.erb
+++ b/config/templates/seed/markets.yml.erb
@@ -6,8 +6,6 @@
   quote_unit:        usd
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001
@@ -19,8 +17,6 @@
   quote_unit:        usd
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001
@@ -32,8 +28,6 @@
   quote_unit:        usd
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001
@@ -45,8 +39,6 @@
   quote_unit:        btc
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001
@@ -58,8 +50,6 @@
   quote_unit:        btc
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001
@@ -71,8 +61,6 @@
   quote_unit:        eth
   amount_precision:  4
   price_precision:   4
-  maker_fee:         0.001
-  taker_fee:         0.0015
   min_price:         0.0001
   max_price:         0.0
   min_amount:        0.0001

--- a/config/templates/seed/trading_fees.yml.erb
+++ b/config/templates/seed/trading_fees.yml.erb
@@ -1,0 +1,29 @@
+<% if ENV['TRADING_FEES_CONFIG'] %>
+<%= File.read(ENV['TRADING_FEES_CONFIG']) %>
+<% else %>
+- market_id:        any
+  group:            any
+  maker:            0.002
+  taker:            0.002
+
+- market_id:        any
+  group:            vip-0
+  maker:            0.001
+  taker:            0.002
+
+- market_id:        any
+  group:            vip-1
+  maker:            0.0008
+  taker:            0.0018
+
+- market_id:        any
+  group:            vip-2
+  maker:            0.006
+  taker:            0.0016
+
+- market_id:        any
+  group:            vip-3
+  maker:            0.0
+  taker:            0.0014
+
+<% end %>

--- a/config/templates/seed/trading_fees.yml.erb
+++ b/config/templates/seed/trading_fees.yml.erb
@@ -18,7 +18,7 @@
 
 - market_id:        any
   group:            vip-2
-  maker:            0.006
+  maker:            0.0006
   taker:            0.0016
 
 - market_id:        any

--- a/db/migrate/20190814102636_create_trading_fees.rb
+++ b/db/migrate/20190814102636_create_trading_fees.rb
@@ -1,0 +1,16 @@
+class CreateTradingFees < ActiveRecord::Migration[5.2]
+  def change
+    create_table :trading_fees do |t|
+
+      t.string :market_id, limit: 20, default: 'any', null: false, index: true, foreign_key: true
+      t.string :group, limit: 32, default: 'any', null: false, index: true
+
+      t.decimal :maker, precision: 5, scale: 4, default: 0, null: false
+      t.decimal :taker, precision: 5, scale: 4, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index :trading_fees, %i[market_id group], unique: true
+  end
+end

--- a/db/migrate/20190816125948_add_group_to_member_drop_fees_from_market.rb
+++ b/db/migrate/20190816125948_add_group_to_member_drop_fees_from_market.rb
@@ -1,0 +1,18 @@
+class AddGroupToMemberDropFeesFromMarket < ActiveRecord::Migration[5.2]
+  def up
+    add_column :members, :group, :string, limit: 32, default: 'vip-0', null: false, after: :role
+    Market.find_each do |m|
+      TradingFee.new(market_id: m.id,
+                     maker: m.maker_fee,
+                     taker: m.taker_fee).save(validate: false)
+    end
+    remove_column :markets, :maker_fee, :decimal, null: false, default: 0, precision: 17, scale: 16
+    remove_column :markets, :taker_fee, :decimal, null: false, default: 0, precision: 17, scale: 16
+  end
+
+  def down
+    remove_column :members, :group
+    add_column :markets, :maker_fee, :decimal, null: false, default: 0, precision: 17, scale: 16
+    add_column :markets, :taker_fee, :decimal, null: false, default: 0, precision: 17, scale: 16
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_13_121822) do
+ActiveRecord::Schema.define(version: 2019_08_16_125948) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "member_id", null: false
@@ -134,8 +134,6 @@ ActiveRecord::Schema.define(version: 2019_08_13_121822) do
     t.string "quote_unit", limit: 10, null: false
     t.integer "amount_precision", limit: 1, default: 4, null: false
     t.integer "price_precision", limit: 1, default: 4, null: false
-    t.decimal "maker_fee", precision: 17, scale: 16, default: "0.0", null: false
-    t.decimal "taker_fee", precision: 17, scale: 16, default: "0.0", null: false
     t.decimal "min_price", precision: 32, scale: 16, default: "0.0", null: false
     t.decimal "max_price", precision: 32, scale: 16, default: "0.0", null: false
     t.decimal "min_amount", precision: 32, scale: 16, default: "0.0", null: false
@@ -154,6 +152,7 @@ ActiveRecord::Schema.define(version: 2019_08_13_121822) do
     t.string "email", null: false
     t.integer "level", null: false
     t.string "role", limit: 16, null: false
+    t.string "group", limit: 32, default: "vip-0", null: false
     t.string "state", limit: 16, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -245,6 +244,18 @@ ActiveRecord::Schema.define(version: 2019_08_13_121822) do
     t.index ["maker_order_id"], name: "index_trades_on_maker_order_id"
     t.index ["market_id", "created_at"], name: "index_trades_on_market_id_and_created_at"
     t.index ["taker_order_id"], name: "index_trades_on_taker_order_id"
+  end
+
+  create_table "trading_fees", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "market_id", limit: 20, default: "any", null: false
+    t.string "group", limit: 32, default: "any", null: false
+    t.decimal "maker", precision: 5, scale: 4, default: "0.0", null: false
+    t.decimal "taker", precision: 5, scale: 4, default: "0.0", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group"], name: "index_trading_fees_on_group"
+    t.index ["market_id", "group"], name: "index_trading_fees_on_market_id_and_group", unique: true
+    t.index ["market_id"], name: "index_trading_fees_on_market_id"
   end
 
   create_table "transfers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,4 @@ Rake::Task['seed:blockchains'].invoke
 Rake::Task['seed:currencies'].invoke
 Rake::Task['seed:markets'].invoke
 Rake::Task['seed:wallets'].invoke
+Rake::Task['seed:trading_fees'].invoke

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -74,4 +74,14 @@ namespace :seed do
       end
     end
   end
+
+  desc 'Adds missing trading_fees to database defined at config/seed/trading_fees.yml.'
+  task trading_fees: :environment do
+    TradingFee.transaction do
+      YAML.load_file(Rails.root.join('config/seed/trading_fees.yml')).each do |hash|
+        next if TradingFee.exists?(market_id: hash.fetch('market_id'), group: hash.fetch('group'))
+        TradingFee.create!(hash)
+      end
+    end
+  end
 end

--- a/spec/api/v2/admin/markets_spec.rb
+++ b/spec/api/v2/admin/markets_spec.rb
@@ -92,7 +92,6 @@ describe API::V2::Admin::Markets, type: :request do
     it 'creates new market' do
       api_post '/api/v2/admin/markets/new', token: token, params: valid_params
       result = JSON.parse(response.body)
-
       expect(response).to be_successful
       expect(result['id']).to eq 'trstbtc'
     end
@@ -136,11 +135,11 @@ describe API::V2::Admin::Markets, type: :request do
 
   describe 'POST /api/v2/admin/markets/update' do
     it 'update market' do
-      api_post '/api/v2/admin/markets/update', params: { id: Market.first.id, taker_fee: 0.4 }, token: token
+      api_post '/api/v2/admin/markets/update', params: { id: Market.first.id, min_price: 0.4 }, token: token
       result = JSON.parse(response.body)
 
       expect(response).to be_successful
-      expect(result['taker_fee']).to eq '0.4'
+      expect(result['min_price']).to eq '0.4'
     end
 
     it 'checkes required params' do

--- a/spec/api/v2/management/members_spec.rb
+++ b/spec/api/v2/management/members_spec.rb
@@ -1,0 +1,46 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe API::V2::Management::Members, type: :request do
+  before do
+    defaults_for_management_api_v1_security_configuration!
+    management_api_v1_security_configuration.merge! \
+      scopes: {
+        write_members:  { permitted_signers: %i[alex jeff], mandatory_signers: %i[alex jeff] },
+      }
+  end
+
+  describe 'set user group' do
+    def request
+      post_json '/api/v2/management/members/group', multisig_jwt_management_api_v1({ data: data }, *signers)
+    end
+
+    let(:data) { {uid: member.uid, group: 'vip-1'} }
+    let(:signers) { %i[alex jeff] }
+    let(:member) { create(:member, :barong) }
+
+    it 'returns user with updated role' do
+      request
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)['group']).to eq('vip-1')
+    end
+
+    context 'invalid uid' do
+      let(:data) { { uid: 'fake_uid', group: 'vip-1' }  }
+      it 'returns status 404 and error' do
+        request
+        expect(response).to have_http_status(404)
+        expect(JSON.parse(response.body)['error']).to eq("Couldn't find record.")
+      end
+    end
+
+    context 'invalid record' do
+      let(:data) { { uid: member.uid, group: 'vip-12222222222222222222222222222' }  }
+      it 'returns status 422 and error' do
+        request
+        expect(response).to have_http_status(422)
+        expect(JSON.parse(response.body)['errors']).to eq("Validation failed: Group is too long (maximum is 32 characters)")
+      end
+    end
+  end
+end

--- a/spec/api/v2/public/markets_spec.rb
+++ b/spec/api/v2/public/markets_spec.rb
@@ -6,7 +6,7 @@ describe API::V2::Public::Markets, type: :request do
   describe 'GET /api/v2/markets' do
 
     let(:expected_keys) do
-      %w[id name base_unit quote_unit maker_fee taker_fee min_price max_price
+      %w[id name base_unit quote_unit min_price max_price
          min_amount amount_precision price_precision state]
     end
 

--- a/spec/controllers/admin/markets_controller_spec.rb
+++ b/spec/controllers/admin/markets_controller_spec.rb
@@ -8,8 +8,6 @@ describe Admin::MarketsController, type: :controller do
     { quote_currency:     'usd',
       price_precision:    4,
       base_currency:      'eth',
-      maker_fee:          '0.003'.to_d,
-      taker_fee:          '0.02'.to_d,
       min_amount:         '0.02'.to_d,
       min_price:          '0.02'.to_d,
       amount_precision:   4,
@@ -43,10 +41,8 @@ describe Admin::MarketsController, type: :controller do
   describe '#update' do
     let :new_attributes do
       { quote_currency:         'btc',
-        bid_fee:          '0.002'.to_d,
         price_precision:    7,
         base_currency:         'eth',
-        ask_fee:          '0.05'.to_d,
         min_amount:       '0.02'.to_d,
         amount_precision: 7,
         state:            :disabled,

--- a/spec/factories/market.rb
+++ b/spec/factories/market.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
       id                { 'btcusd' }
       base_currency     { 'btc' }
       quote_currency    { 'usd' }
-      maker_fee         { 0.0015 }
-      taker_fee         { 0.0015 }
       amount_precision  { 8 }
       price_precision   { 2 }
       min_price         { 0.01 }
@@ -21,8 +19,6 @@ FactoryBot.define do
       id                { 'btceth' }
       base_currency     { 'btc' }
       quote_currency    { 'eth' }
-      maker_fee         { 0.0015 }
-      taker_fee         { 0.0015 }
       amount_precision  { 4 }
       price_precision   { 6 }
       min_price         { 0.000001 }

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     level { 0 }
     uid { "ID#{Faker::Number.unique.hexadecimal(10)}".upcase }
     role { "member" }
+    group { "vip-0" }
     state { "active" }
 
     trait :level_3 do

--- a/spec/factories/trading_fees.rb
+++ b/spec/factories/trading_fees.rb
@@ -1,0 +1,22 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:fee) do
+    Kernel.rand(TradingFee::MIN_FEE..TradingFee::MAX_FEE).to_d
+  end
+
+  sequence(:group) do |n|
+    "vip-#{n}"
+  end
+
+  factory :trading_fee do
+    maker { generate(:fee) }
+    taker { generate(:fee) }
+    group { generate(:group) }
+
+    trait :with_market do
+      market { Market.all.sample }
+    end
+  end
+end

--- a/spec/models/concerns/precision_validator_spec.rb
+++ b/spec/models/concerns/precision_validator_spec.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+class Validatable
+  include ActiveModel::Validations
+  attr_accessor :amount
+  validates :amount, precision: { less_than_or_eq_to: 2 }
+end
+
+describe PrecisionValidator do
+  subject { Validatable.new }
+
+  it 'returns valid record' do
+    subject.stubs(amount: 1)
+    expect(subject).to be_valid
+  end
+
+  it 'returns invalid record with errors' do
+    subject.stubs(amount: 0.001)
+    expect(subject).not_to be_valid
+    expect(subject.errors[:amount]).to include(/precision must be less than or equal to 2/)
+  end
+
+  it 'returns invalid record with errors' do
+    subject.stubs(amount: '0.001')
+    expect(subject).not_to be_valid
+    expect(subject.errors[:amount]).to include(/must be a number/)
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -98,13 +98,13 @@ describe Order, 'precision validations', type: :model do
   it 'validates origin_volume precision' do
     record = order_bid
     expect(record.save).to eq false
-    expect(record.errors[:origin_volume]).to include(/is too precise/i)
+    expect(record.errors[:origin_volume]).to include(/precision must be less than or equal to 8/i)
   end
 
   it 'validates price precision' do
     record = order_ask
     expect(record.save).to eq false
-    expect(record.errors[:price]).to include(/is too precise/i)
+    expect(record.errors[:price]).to include(/precision must be less than or equal to 2/i)
   end
 end
 

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -60,12 +60,6 @@ describe Trade, '#record_complete_operations!' do
 
   subject{ trade }
 
-  let(:maker_fee) { 0.002 }
-  let(:taker_fee) { 0.001 }
-  before do
-    trade.market.update(maker_fee: maker_fee, taker_fee: taker_fee)
-  end
-
   it 'creates four liability operations' do
     expect{ subject.record_complete_operations! }.to change{ Operations::Liability.count }.by(4)
   end

--- a/spec/models/tradinng_fee_spec.rb
+++ b/spec/models/tradinng_fee_spec.rb
@@ -23,6 +23,18 @@ end
 describe TradingFee, 'Validations' do
   before(:each) { TradingFee.delete_all }
 
+  context 'group presence' do
+    context 'nil group' do
+      subject { build(:trading_fee, market_id: :btceth, group: nil) }
+      it { expect(subject.valid?).to be_falsey }
+    end
+
+    context 'empty string group' do
+      subject { build(:trading_fee, market_id: :btceth, group: '') }
+      it { expect(subject.valid?).to be_falsey }
+    end
+  end
+
   context 'group uniqueness' do
     context 'different markets' do
       before { create(:trading_fee, market_id: :btcusd, group: 'vip-1') }
@@ -94,6 +106,18 @@ describe TradingFee, 'Validations' do
     context 'valid trading_fee' do
       subject { build(:trading_fee, maker: 0.1, taker: 0.2) }
       it { expect(subject.valid?).to be_truthy }
+    end
+  end
+
+  context 'market_id presence' do
+    context 'nil group' do
+      subject { build(:trading_fee, market_id: nil) }
+      it { expect(subject.valid?).to be_falsey }
+    end
+
+    context 'empty string group' do
+      subject { build(:trading_fee, market_id: '') }
+      it { expect(subject.valid?).to be_falsey }
     end
   end
 

--- a/spec/models/tradinng_fees_spec.rb
+++ b/spec/models/tradinng_fees_spec.rb
@@ -1,0 +1,189 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe TradingFee, 'Relationships' do
+  context 'belongs to market' do
+    context 'null market_id' do
+      subject { build(:trading_fee) }
+      it { expect(subject.valid?).to be_truthy }
+    end
+
+    context 'existing market_id' do
+      subject { build(:trading_fee, market_id: :btcusd) }
+      it { expect(subject.valid?).to be_truthy }
+    end
+
+    context 'non-existing market_id' do
+      subject { build(:trading_fee, market_id: :usdbtc) }
+      it { expect(subject.valid?).to be_falsey }
+    end
+  end
+end
+
+describe TradingFee, 'Validations' do
+  before(:each) { TradingFee.delete_all }
+
+  context 'group uniqueness' do
+    context 'different markets' do
+      before { create(:trading_fee, market_id: :btcusd, group: 'vip-1') }
+
+      context 'same group' do
+        subject { build(:trading_fee, market_id: :btceth, group: 'vip-1') }
+        it { expect(subject.valid?).to be_truthy }
+      end
+
+      context 'different group' do
+        subject { build(:trading_fee, market_id: :btceth, group: 'vip-2') }
+        it { expect(subject.valid?).to be_truthy }
+      end
+
+      context ':any group' do
+        before { create(:trading_fee, market_id: :btcusd, group: :any) }
+        subject { build(:trading_fee, market_id: :btceth, group: :any) }
+        it { expect(subject.valid?).to be_truthy }
+      end
+    end
+
+    context 'same market' do
+      before { create(:trading_fee, market_id: :btcusd, group: 'vip-1') }
+
+      context 'same group' do
+        subject { build(:trading_fee, market_id: :btcusd, group: 'vip-1') }
+        it { expect(subject.valid?).to be_falsey }
+      end
+
+      context 'different group' do
+        subject { build(:trading_fee, market_id: :btcusd, group: 'vip-2') }
+        it { expect(subject.valid?).to be_truthy }
+      end
+
+      context ':any group' do
+        before { create(:trading_fee, market_id: :btcusd, group: :any) }
+        subject { build(:trading_fee, market_id: :btcusd, group: :any) }
+        it { expect(subject.valid?).to be_falsey }
+      end
+    end
+
+    context ':any market' do
+      before { create(:trading_fee, group: 'vip-1') }
+
+      context 'same group' do
+        subject { build(:trading_fee, group: 'vip-1') }
+        it { expect(subject.valid?).to be_falsey }
+      end
+
+      context 'different group' do
+        subject { build(:trading_fee, group: 'vip-2') }
+        it { expect(subject.valid?).to be_truthy }
+      end
+
+      context ':any group' do
+        before { create(:trading_fee, group: :any) }
+        subject { build(:trading_fee, group: :any) }
+        it { expect(subject.valid?).to be_falsey }
+      end
+    end
+  end
+
+  context 'maker, taker numericality' do
+    context 'non decimal maker/taker' do
+      subject { build(:trading_fee, maker: '1', taker: '1') }
+      it { expect(subject.valid?).to be_falsey }
+    end
+
+    context 'valid trading_fee' do
+      subject { build(:trading_fee, maker: 0.1, taker: 0.2) }
+      it { expect(subject.valid?).to be_truthy }
+    end
+  end
+
+  context 'market_id inclusion in' do
+    context 'invalid market_id' do
+      subject { build(:trading_fee, market_id: :ethusd) }
+      it { expect(subject.valid?).to be_falsey }
+    end
+
+    context 'valid trading_fee' do
+      subject { build(:trading_fee, market_id: :btcusd) }
+      it { expect(subject.valid?).to be_truthy }
+    end
+  end
+end
+
+describe TradingFee, 'Class Methods' do
+  before(:each) { TradingFee.delete_all }
+
+  context '#for' do
+    let!(:member) { create(:member) }
+
+    context 'get trading_fee with marker_id and group' do
+      before do
+        create(:trading_fee, market_id: :btcusd, group: 'vip-0')
+        create(:trading_fee, market_id: :any, group: 'vip-0')
+        create(:trading_fee, market_id: :btcusd, group: :any)
+        create(:trading_fee, market_id: :any, group: :any)
+      end
+
+      let(:order) { Order.new(member: member, market_id: :btcusd) }
+      subject { TradingFee.for(group: order.member.group, market_id: order.market_id) }
+
+      it { expect(subject).to be_truthy }
+      it { expect(subject.market_id).to eq('btcusd') }
+      it { expect(subject.group).to eq('vip-0') }
+    end
+
+    context 'get trading_fee with group' do
+      before do
+        create(:trading_fee, market_id: :any, group: 'vip-1')
+        create(:trading_fee, market_id: :btcusd, group: :any)
+        create(:trading_fee, market_id: :any, group: :any)
+      end
+
+      let(:order) { Order.new(member: member, market_id: :btcusd) }
+      subject { TradingFee.for(group: order.member.group, market_id: order.market_id) }
+
+      it { expect(subject).to be_truthy }
+      it { expect(subject.market_id).to eq('btcusd') }
+      it { expect(subject.group).to eq('any') }
+    end
+
+    context 'get trading_fee with market_id' do
+      before do
+        create(:trading_fee, market_id: :any, group: 'vip-0')
+        create(:trading_fee, market_id: :btcusd, group: :any)
+        create(:trading_fee, market_id: :any, group: :any)
+      end
+
+      let(:order) { Order.new(member: member, market_id: :btceth) }
+      subject { TradingFee.for(group: order.member.group, market_id: order.market_id) }
+
+      it { expect(subject).to be_truthy }
+      it { expect(subject.market_id).to eq('any') }
+      it { expect(subject.group).to eq('vip-0') }
+    end
+
+    context 'get default trading_fee' do
+      before do
+        create(:trading_fee, market_id: :any, group: 'vip-1')
+        create(:trading_fee, market_id: :btcusd, group: :any)
+        create(:trading_fee, market_id: :any, group: :any)
+      end
+
+      let(:order) { Order.new(member: member, market_id: :btceth) }
+      subject { TradingFee.for(group: order.member.group, market_id: order.market_id) }
+
+      it { expect(subject).to be_truthy }
+      it { expect(subject.market_id).to eq('any') }
+      it { expect(subject.group).to eq('any') }
+    end
+
+    context 'get default trading_fee (doesnt create it)' do
+      let(:order) { Order.new(member: member, market_id: :btceth) }
+      subject { TradingFee.for(group: order.member.group, market_id: order.market_id) }
+
+      it { expect(subject).to be_truthy }
+      it { expect(subject.market_id).to eq('any') }
+      it { expect(subject.group).to eq('any') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,7 @@ RSpec.configure do |config|
 
     %i[btcusd btceth].each { |market| FactoryBot.create(:market, market) }
     %w[101 102 201 202 211 212 301 302 401 402].each { |ac_code| FactoryBot.create(:operations_account, ac_code)}
+    FactoryBot.create(:trading_fee, market_id: :any, group: :any, maker: 0.0015, taker: 0.0015)
   end
 
   config.after(:each) do

--- a/spec/trading/matching/executor_spec.rb
+++ b/spec/trading/matching/executor_spec.rb
@@ -164,7 +164,7 @@ describe Matching::Executor do
       let(:bid) { create(:order_bid, :btcusd, price: price, volume: volume, member: bob) }
 
       before do
-        market.update!(maker_fee: 0.01, taker_fee: 0.02)
+        TradingFee.last.update!(maker: 0.01, taker: 0.02)
         subject.execute!
       end
 
@@ -184,7 +184,7 @@ describe Matching::Executor do
       let(:bid) { create(:order_bid, :btcusd, price: price, volume: volume, member: bob) }
 
       before do
-        market.update!(maker_fee: 0.0, taker_fee: 0.02)
+        TradingFee.last.update!(maker: 0.0, taker: 0.02)
         subject.execute!
       end
 


### PR DESCRIPTION
- Add `FeeSchedule` module;
- Add `FeeSchedule::TradingFee` model;
    `FeeSchedule::TradingFee` record selected with the next priorities:
    1. both group and market_id match
    2. group match
    3. market_id match
    4. both group and market_id are nil
    5. default (zero fees)
- Add Group member column;
- Remove `maker/taker_fee` from Market model;
- Add custom validator class `PrecisionValidator` for validate precisions for Order, TradingFee, Market models;
- `FeeSchedule::TradingFees` seeding via rake task;