### PR TITLE
Integrate ability to create accounting Adjustments 

### DIFF
--- a/app/api/v2/admin/adjustments.rb
+++ b/app/api/v2/admin/adjustments.rb
@@ -1,0 +1,136 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      class Adjustments < Grape::API
+        helpers ::API::V2::Admin::Helpers
+
+        desc 'Get all adjustments, result is paginated.',
+          is_array: true,
+          success: API::V2::Admin::Entities::Adjustment
+        params do
+          use :currency
+          use :date_picker
+          use :pagination
+          use :ordering
+          optional :state,
+                   type: String,
+                   values: { value: -> { Adjustment.aasm.states.map(&:name).map(&:to_s) }, message: 'admin.adjustment.invalid_action' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:state][:desc] }
+          optional :category,
+                   type: String,
+                   values: { value: -> { ::Adjustment::CATEGORIES }, message: 'admin.adjustment.invalid_category' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:category][:desc] }
+        end
+        get '/adjustments' do
+          authorize! :read, Adjustment
+
+          ransack_params = Helpers::RansackBuilder.new(params)
+                                                  .eq(:state, :category)
+                                                  .translate(currency: :currency_id)
+                                                  .with_daterange
+                                                  .build
+
+          search = Adjustment.ransack(ransack_params)
+          search.sorts = "#{params[:order_by]} #{params[:ordering]}"
+
+          present paginate(search.result), with: API::V2::Admin::Entities::Adjustment
+        end
+
+        desc 'Create new adjustment.',
+          success: API::V2::Admin::Entities::Adjustment
+        params do
+          requires :reason,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:reason][:desc] }
+          requires :description,
+                   type: String,
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:description][:desc] }
+          requires :category,
+                   type: String,
+                   values: { value: -> { ::Adjustment::CATEGORIES }, message: 'admin.adjustment.invalid_category' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:category][:desc] }
+          requires :amount,
+                   type: { value: BigDecimal, message: 'admin.adjustment.non_decimal_amount' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:amount][:desc] }
+          requires :currency_id,
+                   type: String,
+                   values: { value: -> { ::Currency.codes }, message: 'admin.adjustment.currency_doesnt_exist' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:currency][:desc] }
+          requires :asset_account_code,
+                   type: { value: Integer, message: 'admin.adjustment.non_integer_asset_account_code' },
+                   values: { value: -> { ::Operations::Account.where(type: :asset).pluck(:code) }, message: 'admin.adjustment.invalid_asset_account_code' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:asset_account_code][:desc] }
+          requires :receiving_account_code,
+                   type: { value: Integer, message: 'admin.adjustment.non_integer_receiving_account_code' },
+                   values: { value: -> { ::Operations::Account.where.not(type: :asset).pluck(:code) }, message: 'admin.adjustment.invalid_receiving_account_code' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:receiving_account_code][:desc] }
+          given receiving_account_code: ->(code) { ::Operations::Account.find_by_code(code)&.type == 'liability' } do
+            requires :receiving_member_uid,
+                     type: String,
+                     desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:receiving_account_code][:desc] }
+          end
+          given receiving_account_code: ->(code) { ::Operations::Account.find_by_code(code)&.type == 'revenue' } do
+            optional :receiving_member_uid,
+                     type: String,
+                     desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:receiving_account_code][:desc] }
+          end
+        end
+        post '/adjustments/new' do
+          authorize! :create, Adjustment
+
+          receiving = ::Operations.build_account_number(currency_id: params[:currency_id],
+                                                          account_code: params[:receiving_account_code],
+                                                          member_uid: params[:receiving_member_uid])
+
+          adjustment = Adjustment.new(declared(params)
+                                      .except(:receiving_account_code, :receiving_member_uid)
+                                      .merge(receiving_account_number: receiving,
+                                             creator: current_user))
+          if adjustment.save
+            present adjustment, with: API::V2::Admin::Entities::Adjustment
+            status 201
+          else
+            body errors: adjustment.errors.full_messages
+            status 422
+          end
+        end
+
+        desc 'Accepts adjustment and creates operations or reject adjustment.',
+          success: API::V2::Admin::Entities::Adjustment
+        params do
+          requires :id,
+                   type: { value: Integer, message: 'admin.adjustment.non_integer_id' },
+                   desc: -> { API::V2::Admin::Entities::Adjustment.documentation[:id][:desc] }
+          requires :action,
+                   type: String,
+                   values: { value: -> { Adjustment.aasm.events.map(&:name).map(&:to_s) }, message: 'admin.adjustment.invalid_action' },
+                   desc: "Adjustment action all available actions: #{Adjustment.aasm.events.map(&:name)}"
+          # For action in adjustments we don't need any aditional parameters.
+          # If we will need custom params use this:
+          #   given action: ->(val) { val == 'accept' } do
+          #     custom params
+          #   end
+          #   given action: ->(val) { val == 'reject' } do
+          #     custom params
+          #   end
+        end
+        post '/adjustments/action' do
+          authorize! :write, Adjustment
+          adjustment = Adjustment.find(params[:id])
+
+          if adjustment.public_send("may_#{params[:action]}?")
+            # TODO: Add behaviour in case of errors on action.
+            adjustment.public_send("#{params[:action]}!", validator: current_user)
+            present adjustment, with: API::V2::Admin::Entities::Adjustment
+          else
+            body errors: ["admin.adjustment.cannot_perform_#{params[:action]}_action"]
+            status 422
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/entities/adjustment.rb
+++ b/app/api/v2/admin/entities/adjustment.rb
@@ -1,0 +1,168 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Admin
+      module Entities
+        class Adjustment < API::V2::Entities::Base
+          expose(
+            :id,
+            documentation: {
+              type: Integer,
+              desc: 'Unique adjustment identifier in database.'
+            }
+          )
+
+          expose(
+            :reason,
+            documentation: {
+              type: String,
+              desc: 'Adjustment reason.'
+            }
+          )
+
+          expose(
+            :description,
+            documentation: {
+              type: String,
+              desc: 'Adjustment description.'
+            }
+          )
+
+          expose(
+            :category,
+            documentation: {
+              type: String,
+              desc: 'Adjustment category'
+            }
+          )
+
+          expose(
+            :amount,
+            documentation: {
+              type: String,
+              desc: 'Adjustment amount.'
+            }
+          )
+
+          expose(
+            :validator_uid,
+            documentation: {
+              type: Integer,
+              desc: 'Unique adjustment validator identifier in database.'
+            },
+            if: ->(adjustment, _options) { adjustment.validator }
+          ) do |adjustment, _options|
+            adjustment.validator.uid
+          end
+
+          expose(
+            :creator_uid,
+            documentation: {
+              type: Integer,
+              desc: 'Unique adjustment creator identifier in database.'
+            },
+          ) do |adjustment, _options|
+            adjustment.creator.uid
+          end
+
+          expose(
+            :currency_id,
+            as: :currency,
+            documentation: {
+              type: String,
+              desc: 'Adjustment currency ID.'
+            }
+          )
+
+          expose(
+            :asset,
+            using: API::V2::Admin::Entities::Operation,
+            if: ->(adjustment, _options) { adjustment.fetch_asset }
+          ) do |adjustment, _options|
+            adjustment.fetch_asset
+          end
+
+          expose(
+            :liability,
+            using: API::V2::Admin::Entities::Operation,
+            if: ->(adjustment, _options) { adjustment.fetch_liability }
+          ) do |adjustment, _options|
+            adjustment.fetch_liability
+          end
+
+          expose(
+            :revenue,
+            using: API::V2::Admin::Entities::Operation,
+            if: ->(adjustment, _options) { adjustment.fetch_revenue }
+          ) do |adjustment, _options|
+            adjustment.fetch_revenue
+          end
+
+          expose(
+            :expense,
+            using: API::V2::Admin::Entities::Operation,
+            if: ->(adjustment, _options) { adjustment.fetch_expense }
+          ) do |adjustment, _options|
+            adjustment.fetch_expense
+          end
+
+          expose(
+            :state,
+            documentation: {
+              type: String,
+              desc: 'Adjustment\'s state.'
+            }
+          )
+
+          expose(
+            :asset_account_code,
+            documentation: {
+              type: Integer,
+              desc: 'Adjustment asset account code.'
+            }
+          )
+
+          expose(
+            :receiving_account_code,
+            documentation: {
+              type: String,
+              desc: 'Adjustment receiving account code.'
+            }
+          ) do |adjustment, _options|
+            ::Operations.split_account_number(account_number: adjustment.receiving_account_number)[:code]
+          end
+
+          expose(
+            :receiving_member_uid,
+            documentation: {
+              type: String,
+              desc: 'Adjustment receiving member uid.'
+            }
+          ) do |adjustment, _options|
+            ::Operations.split_account_number(account_number: adjustment.receiving_account_number)[:member_uid]
+          end
+
+          expose(
+            :created_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when operation was created.'
+            }
+          )
+
+          expose(
+            :updated_at,
+            format_with: :iso8601,
+            documentation: {
+              type: String,
+              desc: 'The datetime when operation was updated.'
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/admin/mount.rb
+++ b/app/api/v2/admin/mount.rb
@@ -21,6 +21,7 @@ module API
         mount Admin::Operations
         mount Admin::Members
         mount Admin::TradingFees
+        mount Admin::Adjustments
 
         # The documentation is accessible at http://localhost:3000/swagger?url=/api/v2/admin/swagger
         # Add swagger documentation for Peatio Admin API

--- a/app/models/abilities/accountant.rb
+++ b/app/models/abilities/accountant.rb
@@ -19,6 +19,7 @@ module Abilities
       can :read, PaymentAddress
 
       can :create, Deposits::Fiat
+      can :create, Adjustment
     end
   end
 end

--- a/app/models/abilities/admin.rb
+++ b/app/models/abilities/admin.rb
@@ -24,6 +24,7 @@ module Abilities
       can :manage, Blockchain
       can :manage, Wallet
       can :manage, TradingFee
+      can :manage, Adjustment
 
       can :read, Account
       can :read, PaymentAddress

--- a/app/models/abilities/superadmin.rb
+++ b/app/models/abilities/superadmin.rb
@@ -26,6 +26,7 @@ module Abilities
       can :manage, Wallet
       can :manage, TradingFee
       can :manage, PaymentAddress
+      can :manage, Adjustment
     end
   end
 end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -1,0 +1,158 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+class Adjustment < ApplicationRecord
+  # == Constants ============================================================
+
+  include AASM
+  include AASM::Locking
+  CATEGORIES = %w[asset_registration investment minting_token
+                  balance_anomaly misc refund compensation
+                  incentive bank_fees bank_interest minor]
+
+  # == Attributes ===========================================================
+
+  enum category: CATEGORIES
+
+  enum state: { pending: 1, accepted: 2, rejected: 3 }
+
+  # == Relationships ========================================================
+
+  belongs_to :currency
+  belongs_to :creator, class_name: :Member, required: true
+  belongs_to :validator, class_name: :Member
+
+  # Need to define reference type for avoid fetching operations that not related to Adjustments.
+  # TODO: Find a better way to associate Adjustments with operations.
+  has_one :asset, -> { where(reference_type: 'Adjustment') }, class_name: 'Operations::Asset', foreign_key: :reference_id
+  has_one :liability, -> { where(reference_type: 'Adjustment') }, class_name: 'Operations::Liability', foreign_key: :reference_id
+  has_one :revenue, -> { where(reference_type: 'Adjustment') }, class_name: 'Operations::Revenue', foreign_key: :reference_id
+  has_one :expense, -> { where(reference_type: 'Adjustment') }, class_name: 'Operations::Expense', foreign_key: :reference_id
+
+  # == Validations ==========================================================
+
+  validates :validator, presence: { unless: :pending? }
+  validates :category, inclusion: { in: CATEGORIES }
+  validates :currency_id, inclusion: { in: ->(_) { Currency.codes } }
+
+  validate on: :create do
+    errors.add(:prebuild_operations, 'are invalid') unless prebuild_operations.map(&:valid?).all?(true)
+  end
+
+  # == Extensions ===========================================================
+
+  aasm column: :state, enum: true, whiny_transitions: false do
+    state :pending, initial: true
+    state :accepted
+    state :rejected
+
+    event :accept do
+      transitions from: :pending, to: :accepted, after: :assign_validator do
+        guard do
+          prebuild_operations.map(&:valid?).all?(true)
+        end
+        after do
+          prebuild_operations.map(&:save!)
+          Operations.update_legacy_balance(liability)
+        end
+      end
+    end
+
+    event :reject do
+      transitions from: :pending, to: :rejected, after: :assign_validator
+    end
+  end
+
+  # Custon ransackers.
+
+  ransacker :state, formatter: proc { |v| states[v] } do |parent|
+    parent.table[:state]
+  end
+
+  ransacker :category, formatter: proc { |v| categories[v] } do |parent|
+    parent.table[:category]
+  end
+
+  # == Scopes ===============================================================
+
+  # == Callbacks ============================================================
+
+  # == Instance Methods =====================================================
+
+  def assign_validator(validator:)
+    update!(validator: validator)
+  end
+
+  def fetch_operations
+    if pending? || rejected?
+      prebuild_operations
+    elsif accepted?
+      load_operations
+    end
+  end
+
+  def load_operations
+    operations = %i[asset liability revenue expense].map do |op_type|
+      "Operations::#{op_type.capitalize}".constantize.find_by(reference: self)
+    end
+    operations.compact
+  end
+
+  %i[asset liability revenue expense].each do |op_type|
+    define_method("fetch_#{op_type}") do
+      fetch_operations.find { |op| op.is_a?("Operations::#{op_type.capitalize}".constantize) }
+    end
+  end
+
+  def prebuild_operations
+    account_number_hash = Operations.split_account_number(account_number: receiving_account_number)
+    currency_id = account_number_hash[:currency_id]
+    code = account_number_hash[:code]
+    member = Member.find_by(uid: account_number_hash[:member_uid]) if account_number_hash.key?(:member_uid)
+
+    amount > 0 ? credit = amount : debit = -amount
+
+    klass = Operations.klass_for(code: code)
+
+    params = {
+      currency_id: currency_id,
+      code: asset_account_code,
+      debit: debit.to_d,
+      credit: credit.to_d,
+      reference: self
+    }
+
+    asset = Operations::Asset.new(params)
+    # For expense we need swap debit and credit values due to:
+    # asset - liabilities = revenue - expense
+    params.merge!(credit: debit.to_d, debit: credit.to_d) if klass == Operations::Expense
+    params.merge!(member_id: member.id) if member.present? && klass.column_names.include?('member_id')
+    receiving_operation = klass.new(params.merge(code: code))
+    [asset, receiving_operation]
+  end
+end
+
+# == Schema Information
+# Schema version: 20190830082950
+#
+# Table name: adjustments
+#
+#  id                       :bigint           not null, primary key
+#  reason                   :string(255)      not null
+#  description              :text(65535)      not null
+#  creator_id               :bigint           not null
+#  validator_id             :bigint
+#  amount                   :decimal(32, 16)  not null
+#  asset_account_code       :integer          unsigned, not null
+#  receiving_account_number :string(64)       not null
+#  currency_id              :string(255)      not null
+#  category                 :integer          not null
+#  state                    :integer          not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_adjustments_on_currency_id            (currency_id)
+#  index_adjustments_on_currency_id_and_state  (currency_id,state)
+#

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -13,13 +13,17 @@ class Operation < ApplicationRecord
   validates :currency, :code, presence: true
 
   validate do
-    unless account.currency_type == currency&.type
+    errors.add(:account, 'account doesn\'t exist') unless account
+  end
+
+  validate do
+    unless account&.currency_type == currency&.type
       errors.add(:currency, 'type and account currency type don\'t match')
     end
   end
 
   validate do
-    unless account.type == self.class.operation_type
+    unless account&.type == self.class.operation_type
       errors.add(:base, 'Account type and operation type don\'t match')
     end
   end

--- a/app/models/operations.rb
+++ b/app/models/operations.rb
@@ -1,0 +1,47 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module Operations
+  class << self
+    # TODO: Add specs for this function.
+    def build_account_number(currency_id:, account_code:, member_uid: nil)
+      [currency_id, account_code, member_uid].compact.join('-')
+    end
+
+    def split_account_number(account_number:)
+      currency_id, code, member_uid = account_number.split('-')
+      { currency_id: currency_id,
+        code: code,
+        member_uid: member_uid }
+    end
+
+    def klass_for(code:)
+      "Operations::#{Operations::Account.find_by(code: code).type.capitalize}".constantize
+    end
+
+    def update_legacy_balance(liability)
+      return unless liability.present? || liability.is_a?(Operations::Liability)
+
+      account = liability.account
+      legacy_account = liability.member.accounts.find_by(currency: liability.currency)
+
+      credit = liability.credit
+      debit = liability.debit
+
+      if account.kind.main?
+        if liability.credit.nonzero?
+          legacy_account.plus_funds(credit)
+        else
+          legacy_account.sub_funds(debit)
+        end
+      elsif account.kind.locked?
+        if credit.nonzero?
+          legacy_account.plus_funds(credit)
+          legacy_account.lock_funds(credit)
+        else
+          legacy_account.unlock_ans_sub_funds(debit)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20190830082950_create_adjustments.rb
+++ b/db/migrate/20190830082950_create_adjustments.rb
@@ -1,0 +1,22 @@
+class CreateAdjustments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :adjustments do |t|
+
+      t.string :reason, null: false
+      t.text :description, null: false
+      t.bigint :creator_id, null: false
+      t.bigint :validator_id, null: true
+      t.decimal :amount, precision: 32, scale: 16, null: false
+      t.integer :asset_account_code, limit: 2, unsigned: true, null: false
+      t.string :receiving_account_number, limit: 64, null: false
+      t.string :currency_id, null: false
+      t.integer :category, limit: 1, null: false
+      t.integer :state, limit: 1, null: false
+      t.timestamps null: false
+
+    end
+
+    add_index :adjustments, :currency_id
+    add_index :adjustments, %i[currency_id state]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_035814) do
+ActiveRecord::Schema.define(version: 2019_08_30_082950) do
 
   create_table "accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "member_id", null: false
@@ -21,6 +21,23 @@ ActiveRecord::Schema.define(version: 2019_08_29_035814) do
     t.datetime "updated_at", null: false
     t.index ["currency_id", "member_id"], name: "index_accounts_on_currency_id_and_member_id", unique: true
     t.index ["member_id"], name: "index_accounts_on_member_id"
+  end
+
+  create_table "adjustments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "reason", null: false
+    t.text "description", null: false
+    t.bigint "creator_id", null: false
+    t.bigint "validator_id"
+    t.decimal "amount", precision: 32, scale: 16, null: false
+    t.integer "asset_account_code", limit: 2, null: false, unsigned: true
+    t.string "receiving_account_number", limit: 64, null: false
+    t.string "currency_id", null: false
+    t.integer "category", limit: 1, null: false
+    t.integer "state", limit: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["currency_id", "state"], name: "index_adjustments_on_currency_id_and_state"
+    t.index ["currency_id"], name: "index_adjustments_on_currency_id"
   end
 
   create_table "assets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/api/v2/admin/adjustments_spec.rb
+++ b/spec/api/v2/admin/adjustments_spec.rb
@@ -1,0 +1,355 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe API::V2::Admin::Adjustments, type: :request do
+  let(:admin) { create(:member, :admin, :level_3, email: 'example@gmail.com', uid: 'ID73BF61C8H0') }
+  let(:token) { jwt_for(admin) }
+  let(:member) { create(:member) }
+
+  describe 'GET /api/v2/admin/adjustments' do
+    let!(:adjustments) do
+      create(:adjustment, currency_id: 'btc')
+      create(:adjustment, currency_id: 'btc')
+      create(:adjustment, currency_id: 'btc')
+    end
+    let!(:accepted) { create(:adjustment, currency_id: 'btc', receiving_account_number: "BTC-202-#{member.uid}").tap { |a| a.accept!(validator: member) } }
+    let!(:rejected) { create(:adjustment, currency_id: 'btc', receiving_account_number: "BTC-202-#{member.uid}").tap { |a| a.reject!(validator: member) } }
+
+    it 'get all adjustments' do
+      api_get '/api/v2/admin/adjustments', token: token
+      result = JSON.parse(response.body)
+
+      expect(response).to be_successful
+      expect(response.headers['Total'].to_i).to eq Adjustment.count
+      expect(result.length).to eq Adjustment.count
+    end
+
+    context 'with rejected/accepted' do
+      it 'fetches operations from db' do
+        api_get '/api/v2/admin/adjustments', token: token
+        result = JSON.parse(response.body)
+
+        expect(response).to be_successful
+        expect(result.length).to eq 5
+        expect(result[-1].key?('asset')).to be_truthy
+        expect(result[-1].key?('liability')).to be_truthy
+        expect(result[-1]['state']).to eq('rejected')
+        # We don't create operations for rejected adj.
+        expect(result[-1]['liability']['id'].nil?).to be_truthy
+        expect(result[-1]['asset']['id'].nil?).to be_truthy
+        expect(result[-2].key?('asset')).to be_truthy
+        expect(result[-2].key?('liability')).to be_truthy
+        expect(result[-2]['liability']['id']).to eq accepted.liability.id
+        expect(result[-2]['asset']['id']).to eq accepted.asset.id
+        expect(result[-2]['state']).to eq('accepted')
+      end
+    end
+
+    context 'with filters' do
+      let!(:adjustment_with_category) { create(:adjustment, currency_id: 'btc', category: 'balance_anomaly', receiving_account_number: "BTC-202-#{member.uid}") }
+      let!(:eth_adjustment) { create(:adjustment, currency_id: 'eth', receiving_account_number: "eth-202-#{member.uid}").tap { |a| a.accept!(validator: member) } }
+
+      it 'filter by accepted state' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { state: 'accepted' }
+        result = JSON.parse(response.body)
+
+        expect(response).to be_successful
+        expect(response.headers['Total'].to_i).to eq(Adjustment.where(state: 'accepted').count)
+        expect(result.first['id']).to eq(accepted.id)
+      end
+
+      it 'filter by rejected state' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { state: 'rejected' }
+        result = JSON.parse(response.body)
+
+        expect(response).to be_successful
+        expect(response.headers['Total'].to_i).to eq(Adjustment.where(state: 'rejected').count)
+        expect(result.first['id']).to eq(rejected.id)
+      end
+
+      it 'filters by eth currency' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { currency: 'eth' }
+
+        result = JSON.parse(response.body)
+
+        expect(response).to be_successful
+        expect(response.headers['Total'].to_i).to eq(Adjustment.where(currency_id: 'eth').count)
+        expect(result.first['id']).to eq(eth_adjustment.id)
+      end
+
+      it 'filters by btc currency' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { currency: 'btc' }
+
+        expect(response).to be_successful
+        expect(response.headers['Total'].to_i).to eq(Adjustment.where(currency_id: 'btc').count)
+      end
+
+      it 'validates currency' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { currency: 'uah' }
+
+        expect(response.status).to eq 422
+        expect(response).to include_api_error('admin.currency.doesnt_exist')
+      end
+
+      it 'filter by accepted category' do
+        api_get '/api/v2/admin/adjustments', token: token, params: { category: 'balance_anomaly' }
+        result = JSON.parse(response.body)
+
+        expect(response).to be_successful
+        expect(response.headers['Total'].to_i).to eq(Adjustment.where(category: 'balance_anomaly').count)
+        expect(result.first['id']).to eq(adjustment_with_category.id)
+      end
+    end
+  end
+
+  describe 'POST /api/v2/admin/adjustments/new' do
+    let(:params) do
+      {
+        reason: 'Adjustment',
+        description: 'sample sdjustment',
+        category: 'asset_registration',
+        amount: 100.0,
+        currency_id: :btc,
+        asset_account_code: 102,
+        receiving_account_code: 202,
+        receiving_member_uid: member.uid
+      }
+    end
+
+    it 'creates new adjustment' do
+      expect {
+        api_post '/api/v2/admin/adjustments/new', token: token, params: params
+      }.to change { Adjustment.count }.by 1
+
+      expect(response).to be_successful
+    end
+
+    it 'returns new adjustment and prebuild operations' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params
+
+      result = JSON.parse(response.body)
+      expect(result['reason']).to eq('Adjustment')
+      expect(result['description']).to eq('sample sdjustment')
+      expect(result['category']).to eq('asset_registration')
+      expect(result['amount']).to eq('100.0')
+      expect(result['currency']).to eq('btc')
+      expect(result.key?('asset')).to be_truthy
+      expect(result.key?('liability')).to be_truthy
+    end
+
+    it 'checks account decimal amount' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(amount: '100btc')
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('admin.adjustment.non_decimal_amount')
+    end
+
+    it 'checks right asset_account_code' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(asset_account_code: 111)
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('admin.adjustment.invalid_asset_account_code')
+    end
+
+    it 'checks right receiving_account_code' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(receiving_account_code: 444)
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('admin.adjustment.invalid_receiving_account_code')
+    end
+
+    it 'validates right category' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(category: 'some_category')
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('admin.adjustment.invalid_category')
+    end
+
+    it 'validates right currency' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(currency_id: 'uah')
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('admin.adjustment.currency_doesnt_exist')
+    end
+
+    it 'validates coin and fiat accounts numbers' do
+      api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(currency_id: 'btc', asset_account_code: 101)
+
+      expect(response).not_to be_successful
+      expect(response).to include_api_error('Prebuild operations are invalid')
+    end
+
+    context 'receiving_member_uid requirenment validatation' do
+      it 'requires for liability receiving account' do
+        api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(receiving_account_code: 202).except(:receiving_member_uid)
+
+        expect(response).not_to be_successful
+        expect(response).to include_api_error('admin.adjustment.missing_receiving_member_uid')
+      end
+
+      it 'doesnt requires for revenue receiving account' do
+        api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(receiving_account_code: 302).except(:receiving_member_uid)
+
+        expect(response).to be_successful
+        result = JSON.parse(response.body)
+        expect(result['reason']).to eq('Adjustment')
+      end
+
+
+      it 'doesnt requires for expense receiving account' do
+        api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(receiving_account_code: 402).except(:receiving_member_uid)
+
+        expect(response).to be_successful
+        result = JSON.parse(response.body)
+        expect(result['reason']).to eq('Adjustment')
+      end
+
+      it 'create adjustment with revenue for specific member' do
+        api_post '/api/v2/admin/adjustments/new', token: token, params: params.merge(receiving_account_code: 302)
+
+        expect(response).to be_successful
+        result = JSON.parse(response.body)
+        expect(result['reason']).to eq('Adjustment')
+        expect(result['revenue'].key?('uid')).to be_truthy
+      end
+    end
+  end
+
+  describe 'POST /api/v2/admin/adjustments/action (accept)' do
+    let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}") }
+
+    it 'accepts adjustment' do
+      expect {
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+      }.to change { adjustment.reload.state }.to('accepted')
+      .and change { Operations::Asset.count }.by(1)
+      .and change { Operations::Liability.count }.by(1)
+
+      expect(response).to be_successful
+    end
+
+    it 'udpates member\'s balance' do
+      expect {
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+      }.to change { member.accounts.find_by(currency: adjustment.currency).balance }.by(adjustment.amount)
+    end
+
+    it 'does not accept invalid asset_account_code.' do
+      adjustment.update(asset_account_code: 3000)
+
+      api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+
+      expect(adjustment.reload.state).to eq('pending')
+      expect(response.code).to eq '422'
+      expect(response).to include_api_error('admin.adjustment.cannot_perform_accept_action')
+    end
+
+    context 'already accepted' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}").tap { |a| a.accept!(validator: member) } }
+
+      it 'returns status and error' do
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+
+        expect(response.code).to eq '422'
+        expect(response).to include_api_error('admin.adjustment.cannot_perform_accept_action')
+      end
+
+      it 'does not udpate member\'s balance' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+        }.not_to change { member.accounts }
+      end
+
+      it 'does not create operations' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+        }.not_to change { Operations::Asset.count }
+      end
+    end
+
+    context 'already rejected' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}").tap { |a| a.reject!(validator: member) } }
+
+      it 'returns status and error' do
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+
+        expect(response.code).to eq '422'
+        expect(response).to include_api_error('admin.adjustment.cannot_perform_accept_action')
+      end
+
+      it 'does not udpate member\'s balance' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+        }.not_to change { member.accounts }
+      end
+
+      it 'does not create operations' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+        }.not_to change { Operations::Asset.count }
+      end
+    end
+  end
+
+  describe 'POST /api/v2/admin/adjustments/action (reject)' do
+    let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}") }
+
+    it 'rejects adjustment' do
+      expect {
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+      }.to change { adjustment.reload.state }.to('rejected')
+    end
+
+    it 'does not create operations' do
+      expect {
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+      }.not_to change { Operations::Asset.count }
+    end
+
+    context 'already rejected' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}").tap { |a| a.reject!(validator: member) } }
+
+      it 'returns status and error' do
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :accept }
+
+        expect(response.code).to eq '422'
+        expect(response).to include_api_error('admin.adjustment.cannot_perform_accept_action')
+      end
+
+      it 'does not udpate member\'s balance' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+        }.not_to change { member.accounts }
+      end
+
+      it 'does not create operations' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+        }.not_to change { Operations::Asset.count }
+      end
+    end
+
+    context 'already accepted' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}").tap { |a| a.accept!(validator: member) } }
+
+      it 'returns status and error' do
+        api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+
+        expect(response.code).to eq '422'
+        expect(response).to include_api_error('admin.adjustment.cannot_perform_reject_action')
+      end
+
+      it 'does not udpate member\'s balance' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+        }.not_to change { member.accounts }
+      end
+
+      it 'does not create operations' do
+        expect {
+          api_post '/api/v2/admin/adjustments/action', token: token, params: { id: adjustment.id, action: :reject }
+        }.not_to change { Operations::Asset.count }
+      end
+    end
+  end
+end

--- a/spec/factories/adjustment.rb
+++ b/spec/factories/adjustment.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :adjustment do
+    reason { Faker::Coffee.blend_name }
+    description { Faker::Coffee.notes }
+    category { 'asset_registration' }
+    amount { Faker::Number.positive }
+    currency_id { Currency.ids.sample }
+    creator { create(:member) }
+    asset_account_code { 102 }
+    receiving_account_number { "BTC-#{[402, 302].sample}" }
+  end
+end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -1,0 +1,170 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+describe Adjustment do
+  let!(:member) { create(:member) }
+  subject { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}") }
+
+  context 'on create' do
+    it 'does not insert liability' do
+      expect {
+        subject
+      }.not_to change { Operations::Liability.count }
+    end
+
+    it 'does not insert asset' do
+      expect {
+        subject
+      }.not_to change { Operations::Asset.count }
+    end
+
+    it 'builds operations' do
+      operations = subject.fetch_operations
+
+      expect(operations).not_to be_empty
+      expect(operations.length).to eq 2
+      expect(operations.map(&:valid?)).to be_truthy
+      expect(operations.map(&:reference_type)).to all eq 'Adjustment'
+    end
+  end
+
+  context '#prebuild_operations' do
+    subject { adjustment.prebuild_operations }
+
+    context 'asset and liability' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}", amount: 1) }
+
+      it { expect(subject.first.is_a?(Operations::Asset)).to be_truthy }
+      it { expect(subject.second.is_a?(Operations::Liability)).to be_truthy }
+      it { expect(subject.first.credit).to eq(1) }
+      it { expect(subject.second.credit).to eq(1) }
+
+      context 'negative amount' do
+        let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-202-#{member.uid}", amount: -1) }
+
+        it { expect(subject.first.debit).to eq(1) }
+        it { expect(subject.second.debit).to eq(1) }
+      end
+    end
+
+    context 'asset and revenue' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-302", amount: 1) }
+
+      it { expect(subject.first.is_a?(Operations::Asset)).to be_truthy }
+      it { expect(subject.second.is_a?(Operations::Revenue)).to be_truthy }
+      it { expect(subject.first.credit).to eq(1) }
+      it { expect(subject.second.credit).to eq(1) }
+
+      context 'negative amount' do
+        let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-302", amount: -1) }
+
+        it { expect(subject.first.debit).to eq(1) }
+        it { expect(subject.second.debit).to eq(1) }
+      end
+    end
+
+    context 'asset and expense' do
+      let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-402", amount: 1) }
+
+      it { expect(subject.first.is_a?(Operations::Asset)).to be_truthy }
+      it { expect(subject.second.is_a?(Operations::Expense)).to be_truthy }
+      it { expect(subject.first.credit).to eq(1) }
+      it { expect(subject.second.debit).to eq(1) }
+
+      context 'negative amount' do
+        let!(:adjustment) { create(:adjustment, currency_id: 'btc', receiving_account_number: "btc-402", amount: -1) }
+
+        it { expect(subject.first.debit).to eq(1) }
+        it { expect(subject.second.credit).to eq(1) }
+      end
+    end
+  end
+
+  context 'on accept' do
+    it { expect { subject.accept!(validator: member) }.to change { Operations::Asset.count }.by(1) }
+    it { expect { subject.accept!(validator: member) }.to change { Operations::Liability.count }.by(1) }
+    it { expect { subject.accept!(validator: member) }.to change { subject.state }.to('accepted') }
+
+    it 'operaions have correct reference' do
+      subject.accept!(validator: member)
+      operations = subject.fetch_operations
+      expect(operations.map(&:reference_type)).to all eq 'Adjustment'
+      expect(operations.map(&:reference_id)).to all eq subject.id
+    end
+
+    it 'updates legacy balances' do
+      expect {
+        subject.accept!(validator: member)
+      }.to change { member.accounts.find_by(currency: subject.currency).balance }.by(subject.amount)
+    end
+
+    it 'does not accept with invalid attributes' do
+      subject.update(asset_account_code: 101)
+
+      expect {
+        subject.accept!(validator: member)
+      }.to_not change { subject.state }
+    end
+
+    it 'does not accept without validator' do
+      subject.update(asset_account_code: 101)
+
+      expect {
+        subject.accept!(validator: nil)
+      }.to_not change { subject.state }
+    end
+
+    it 'does not create operations with invalid attributes' do
+      subject.update(asset_account_code: 101)
+      expect {
+        subject.accept!(validator: member)
+      }.not_to change { Operations::Asset.count }
+
+      expect {
+        subject.accept!(validator: member)
+      }.not_to change { Operations::Liability.count }
+    end
+
+    context 'accepted' do
+      before { subject.accept!(validator: member) }
+
+      it { expect { subject.accept!(validator: member) }.not_to change { subject.state } }
+      it { expect { subject.accept!(validator: member) }.not_to change { member.accounts } }
+      it { expect { subject.reject!(validator: member) }.not_to change { subject.state } }
+    end
+
+    context 'accept without validator_id (presence validation)' do
+      before { subject.update(state: 'accepted') }
+
+      it { expect(*subject.errors.full_messages).to eq('Validator can\'t be blank') }
+    end
+
+    context 'accept with validator_id (presence validation)' do
+      before { subject.update(state: 'accepted', validator: member) }
+
+      it { expect(subject.save).to be_truthy }
+    end
+  end
+
+  context 'on reject' do
+    it { expect { subject.reject!(validator: member) }.to change { subject.state }.to('rejected') }
+
+    it 'does not reject without validator' do
+      subject.update(asset_account_code: 101)
+
+      expect {
+        subject.reject!(validator: nil)
+      }.to_not change { subject.state }
+    end
+
+    context 'rejected' do
+      before do
+        subject.reject!(validator: member)
+      end
+
+      it { expect { subject.accept!(validator: member) }.not_to change { subject.state } }
+      it { expect { subject.accept!(validator: member) }.not_to change { member.accounts } }
+      it { expect { subject.reject!(validator: member) }.not_to change { subject.state } }
+    end
+  end
+end

--- a/spec/models/global_spec.rb
+++ b/spec/models/global_spec.rb
@@ -5,7 +5,7 @@ describe Global, '.avg_h24_price' do
 
   before { clear_redis }
   after { clear_redis }
-  
+
   let(:market) { Market.all.sample.id.to_sym }
   let(:global) { Global[market] }
   context 'no trades executed' do


### PR DESCRIPTION
- Add Adjustment model;
- Adjustement has `pending`, `accepted` and `rejected` states;
- Only on `accepted` state creates operations;
- Add API for `get`, `create` and `accept/reject` adjustments;
- Adjustment creates a pair with `asset` and `liabilty` || `revenue` || `expense`;
- Update user balance in case of creation liability after accepting adjustment;