### PR TITLE
Integrate ability to withdraw both fiat & crypto with Beneficiary model

### DIFF
--- a/app/api/v2/account/beneficiaries.rb
+++ b/app/api/v2/account/beneficiaries.rb
@@ -86,12 +86,17 @@ module API
             currency = Currency.find_by!(id: params[:currency_id])
             if currency.coin? && declared_params.dig(:data, :address).blank?
               error!({ errors: ['account.beneficiary.missing_address_in_data'] }, 422)
+            elsif currency.fiat? && declared_params.dig(:data, :full_name).blank?
+              error!({ errors: ['account.beneficiary.missing_full_name_in_data'] }, 422)
             end
 
             present current_user
                       .beneficiaries
                       .create!(declared_params),
                     with: API::V2::Entities::Beneficiary
+          rescue ActiveRecord::RecordInvalid => e
+            report_exception(e)
+            error!({ errors: ['account.beneficiary.failed_to_create'] }, 422)
           end
 
           desc 'Activates beneficiary with pin',

--- a/app/api/v2/account/withdraws.rb
+++ b/app/api/v2/account/withdraws.rb
@@ -35,19 +35,19 @@ module API
                       .tap { |q| present paginate(q), with: API::V2::Entities::Withdraw }
         end
 
-        desc 'Creates new crypto withdrawal.'
+        desc 'Creates new withdrawal to active beneficiary.'
         params do
           requires :otp,
                    type: { value: Integer, message: 'account.withdraw.non_integer_otp' },
                    allow_blank: false,
                    desc: 'OTP to perform action'
-          requires :rid,
-                   type: String,
+          requires :beneficiary_id,
+                   type: { value: Integer, message: 'account.withdraw.non_integer_beneficiary_id' },
                    allow_blank: false,
-                   desc: 'Wallet address on the Blockchain.'
+                   desc: 'ID of Active Beneficiary belonging to user.'
           requires :currency,
                    type: String,
-                   values: { value: -> { Currency.coins.codes(bothcase: true) }, message: 'account.currency.doesnt_exist'},
+                   values: { value: -> { Currency.enabled.codes(bothcase: true) }, message: 'account.currency.doesnt_exist'},
                    desc: 'The currency code.'
           requires :amount,
                    type: { value: BigDecimal, message: 'account.withdraw.non_decimal_amount' },
@@ -61,17 +61,28 @@ module API
         post '/withdraws' do
           withdraw_api_must_be_enabled!
 
+          beneficiary = current_user
+                          .beneficiaries
+                          .available_to_member
+                          .find_by(id: params[:beneficiary_id])
+
+          if beneficiary.blank?
+            error!({ errors: ['account.beneficiary.doesnt_exist'] }, 422)
+          elsif !beneficiary.active?
+            error!({ errors: ['account.beneficiary.invalid_state_for_withdrawal'] }, 422)
+          end
+
           unless Vault::TOTP.validate?(current_user.uid, params[:otp])
             error!({ errors: ['account.withdraw.invalid_otp'] }, 422)
           end
 
           currency = Currency.find(params[:currency])
-          withdraw = ::Withdraws::Coin.new \
-            sum:            params[:amount],
-            member:         current_user,
-            currency:       currency,
-            rid:            params[:rid],
-            note:           params[:note]
+          withdraw = "withdraws/#{currency.type}".camelize.constantize.new \
+            beneficiary: beneficiary,
+            sum:         params[:amount],
+            member:      current_user,
+            currency:    currency,
+            note:        params[:note]
           withdraw.save!
           withdraw.with_lock { withdraw.submit! }
           present withdraw, with: API::V2::Entities::Withdraw
@@ -81,6 +92,9 @@ module API
           error!({ errors: ['account.withdraw.insufficient_balance'] }, 422)
         rescue ActiveRecord::RecordInvalid => e
           report_exception_to_screen(e)
+          # TODO: Check if there are other errors possible here.
+          # For now single error which is not handled by params validations is
+          # sum precision validation error (PrecisionValidator).
           error!({ errors: ['account.withdraw.invalid_amount'] }, 422)
         rescue => e
           report_exception_to_screen(e)

--- a/app/api/v2/admin/entities/withdraw.rb
+++ b/app/api/v2/admin/entities/withdraw.rb
@@ -16,6 +16,14 @@ module API
           )
 
           expose(
+            :beneficiary,
+            using: API::V2::Entities::Beneficiary,
+            if: ->(withdraw, options) do
+              options[:with_beneficiary] && withdraw.beneficiary.present?
+            end
+          )
+
+          expose(
             :uid,
             documentation: {
               type: String,

--- a/app/api/v2/admin/withdraws.rb
+++ b/app/api/v2/admin/withdraws.rb
@@ -9,7 +9,7 @@ module API
 
         desc 'Get all withdraws, result is paginated.',
           is_array: true,
-          success: API::V2::Admin::Entities::Deposit
+          success: API::V2::Admin::Entities::Withdraw
         params do
           optional :state,
                    values: { value: -> { Withdraw::STATES.map(&:to_s) }, message: 'admin.withdraw.invalid_state' },
@@ -50,6 +50,22 @@ module API
           search.sorts = "#{params[:order_by]} #{params[:ordering]}"
 
           present paginate(search.result), with: API::V2::Admin::Entities::Withdraw
+        end
+
+        desc 'Get withdraw by ID.',
+             success: API::V2::Admin::Entities::Withdraw
+        params do
+          requires :id,
+                   type: { value: Integer, message: 'admin.withdraw.non_integer_id' },
+                   desc: -> { API::V2::Admin::Entities::Withdraw.documentation[:id][:desc] }
+        end
+        get '/withdraws/:id' do
+          authorize! :read, Withdraw
+
+          withdraw = Withdraw.find_by!(id: params[:id])
+          present withdraw,
+                  with: API::V2::Admin::Entities::Withdraw,
+                  with_beneficiary: true
         end
 
         desc 'Take an action on the withdrawal.',

--- a/app/models/concerns/fee_chargeable.rb
+++ b/app/models/concerns/fee_chargeable.rb
@@ -26,16 +26,18 @@ module FeeChargeable
       before_validation on: :create do
         next unless currency
 
-        if sum.present?
-          self.sum = sum.round(currency.precision, BigDecimal::ROUND_DOWN)
-        end
-
         self.sum  ||= 0.to_d
         self.fee  ||= currency.withdraw_fee
         self.amount = sum - fee
       end
 
-      validates :sum, presence: true, numericality: { greater_than: 0.to_d }
+      validates :sum,
+                presence: true,
+                numericality: { greater_than: 0.to_d },
+                precision: { less_than_or_eq_to: ->(w) { w.currency.precision } }
+
+      validates :amount,
+                precision: { less_than_or_eq_to: ->(w) { w.currency.precision } }
 
       validate on: :create do
         next if !account || [sum, amount, fee].any?(&:blank?)

--- a/app/models/withdraws/coin.rb
+++ b/app/models/withdraws/coin.rb
@@ -50,28 +50,29 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190725131843
+# Schema version: 20190904143050
 #
 # Table name: withdraws
 #
-#  id           :integer          not null, primary key
-#  account_id   :integer          not null
-#  member_id    :integer          not null
-#  currency_id  :string(10)       not null
-#  amount       :decimal(32, 16)  not null
-#  fee          :decimal(32, 16)  not null
-#  txid         :string(128)
-#  aasm_state   :string(30)       not null
-#  block_number :integer
-#  sum          :decimal(32, 16)  not null
-#  type         :string(30)       not null
-#  tid          :string(64)       not null
-#  rid          :string(95)       not null
-#  note         :string(256)
-#  error        :json
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  completed_at :datetime
+#  id             :integer          not null, primary key
+#  account_id     :integer          not null
+#  member_id      :integer          not null
+#  beneficiary_id :bigint
+#  currency_id    :string(10)       not null
+#  amount         :decimal(32, 16)  not null
+#  fee            :decimal(32, 16)  not null
+#  txid           :string(128)
+#  aasm_state     :string(30)       not null
+#  block_number   :integer
+#  sum            :decimal(32, 16)  not null
+#  type           :string(30)       not null
+#  tid            :string(64)       not null
+#  rid            :string(95)       not null
+#  note           :string(256)
+#  error          :json
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  completed_at   :datetime
 #
 # Indexes
 #

--- a/app/models/withdraws/fiat.rb
+++ b/app/models/withdraws/fiat.rb
@@ -8,28 +8,29 @@ module Withdraws
 end
 
 # == Schema Information
-# Schema version: 20190725131843
+# Schema version: 20190904143050
 #
 # Table name: withdraws
 #
-#  id           :integer          not null, primary key
-#  account_id   :integer          not null
-#  member_id    :integer          not null
-#  currency_id  :string(10)       not null
-#  amount       :decimal(32, 16)  not null
-#  fee          :decimal(32, 16)  not null
-#  txid         :string(128)
-#  aasm_state   :string(30)       not null
-#  block_number :integer
-#  sum          :decimal(32, 16)  not null
-#  type         :string(30)       not null
-#  tid          :string(64)       not null
-#  rid          :string(95)       not null
-#  note         :string(256)
-#  error        :json
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  completed_at :datetime
+#  id             :integer          not null, primary key
+#  account_id     :integer          not null
+#  member_id      :integer          not null
+#  beneficiary_id :bigint
+#  currency_id    :string(10)       not null
+#  amount         :decimal(32, 16)  not null
+#  fee            :decimal(32, 16)  not null
+#  txid           :string(128)
+#  aasm_state     :string(30)       not null
+#  block_number   :integer
+#  sum            :decimal(32, 16)  not null
+#  type           :string(30)       not null
+#  tid            :string(64)       not null
+#  rid            :string(95)       not null
+#  note           :string(256)
+#  error          :json
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  completed_at   :datetime
 #
 # Indexes
 #

--- a/db/migrate/20190904143050_add_beneficiary_id_to_withdraw.rb
+++ b/db/migrate/20190904143050_add_beneficiary_id_to_withdraw.rb
@@ -1,0 +1,5 @@
+class AddBeneficiaryIdToWithdraw < ActiveRecord::Migration[5.2]
+  def change
+    add_column :withdraws, :beneficiary_id, :bigint, null: true, after: :member_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_050444) do
   create_table "withdraws", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "account_id", null: false
     t.integer "member_id", null: false
+    t.bigint "beneficiary_id"
     t.string "currency_id", limit: 10, null: false
     t.decimal "amount", precision: 32, scale: 16, null: false
     t.decimal "fee", precision: 32, scale: 16, null: false

--- a/spec/api/v2/account/beneficiaries_spec.rb
+++ b/spec/api/v2/account/beneficiaries_spec.rb
@@ -247,6 +247,8 @@ describe API::V2::Account::Beneficiaries, 'POST', type: :request do
           expect(response).to include_api_error('account.beneficiary.missing_address_in_data')
         end
       end
+
+      # TODO: Test nil full_name in data for both fiat and crypto.
     end
 
     context 'fiat beneficiary' do
@@ -255,15 +257,13 @@ describe API::V2::Account::Beneficiaries, 'POST', type: :request do
           currency: :usd,
           name: Faker::Bank.name,
           description: Faker::Company.catch_phrase,
-          data: {
-            iban: Faker::Bank.iban,
-            bank: Faker::Bank.name
-          }
+          data: generate(:fiat_beneficiary_data)
         }
       end
 
       context 'nil address in data' do
         it do
+          fiat_beneficiary_data[:data].delete(:address)
           api_post endpoint, params: fiat_beneficiary_data, token: token
           expect(response.status).to eq 201
         end

--- a/spec/api/v2/account/withdraws_spec.rb
+++ b/spec/api/v2/account/withdraws_spec.rb
@@ -90,146 +90,191 @@ describe API::V2::Account::Withdraws, type: :request do
   end
 
   describe 'create withdraw' do
-    let(:currency) { Currency.coins.sample }
-    let(:amount) { 0.1575 }
-    let :data do
-      { uid:      member.uid,
-        currency: currency.code,
-        amount:   amount,
-        rid:      Faker::Blockchain::Bitcoin.address,
-        otp:      123456 }
+    let(:currency) { Currency.enabled.sample; Currency.find(:usd) }
+    let(:amount) { 0.15 }
+
+    let(:beneficiary) do
+      create(:beneficiary, member: member, state: :active, currency: currency)
     end
+
+    let :data do
+      { uid:            member.uid,
+        currency:       currency.code,
+        amount:         amount,
+        beneficiary_id: beneficiary.id,
+        otp:            123456 }
+    end
+
     let(:account) { member.accounts.with_currency(currency).first }
     let(:balance) { 1.2 }
     let(:long_note) { (0...257).map { (65 + rand(26)).chr }.join }
     before { account.plus_funds(balance) }
     before { Vault::TOTP.stubs(:validate?).returns(true) }
 
-    context 'fiat withdrawal' do
-      before { data[:currency] = Currency.fiats.pluck(:id).sample }
-      it 'doesn\'t allow fiat' do
+    context 'disabled account withdrawal API' do
+      before { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'false' }
+      after { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'true' }
+      it 'doesn\'t allow account withdrawal API call' do
         api_post '/api/v2/account/withdraws', params: data, token: token
         expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.currency.doesnt_exist')
+        expect(response).to include_api_error('account.withdraw.disabled_api')
       end
     end
 
-    context 'crypto withdrawal' do
-      context 'disabled account withdrawal API' do
-        before { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'false' }
-        after { ENV['ENABLE_ACCOUNT_WITHDRAWAL_API'] = 'true' }
-        it 'doesn\'t allow account withdrawal API call' do
+    context 'extremely precise values' do
+      before { Currency.any_instance.stubs(:withdraw_fee).returns(BigDecimal(0)) }
+      before { Currency.any_instance.stubs(:precision).returns(16) }
+      it 'keeps precision for amount' do
+        data[:amount] = '0.0000000123456789'
+        api_post '/api/v2/account/withdraws', params: data, token: token
+        expect(response).to have_http_status(201)
+        expect(Withdraw.last.sum.to_s).to eq data[:amount]
+      end
+    end
+
+    it 'validates missing params' do
+      data.except!(:otp, :amount, :currency, :beneficiary_id)
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.missing_otp')
+      expect(response).to include_api_error('account.withdraw.missing_amount')
+      expect(response).to include_api_error('account.withdraw.missing_currency')
+      expect(response).to include_api_error('account.withdraw.missing_beneficiary_id')
+    end
+
+    context 'invalid beneficiary_id' do
+      context 'non-existing' do
+        it do
+          data[:beneficiary_id] = data[:beneficiary_id] + 1
           api_post '/api/v2/account/withdraws', params: data, token: token
           expect(response).to have_http_status(422)
-          expect(response).to include_api_error('account.withdraw.disabled_api')
+          expect(response).to include_api_error('account.beneficiary.doesnt_exist')
         end
       end
 
-      context 'extremely precise values' do
-        before { Currency.any_instance.stubs(:withdraw_fee).returns(BigDecimal(0)) }
-        before { Currency.any_instance.stubs(:precision).returns(16) }
-        it 'keeps precision for amount' do
-          currency.update!(precision: 16)
-          data[:amount] = '0.0000000123456789'
+      context 'archived' do
+        before { beneficiary.update(state: :archived) }
+        it do
           api_post '/api/v2/account/withdraws', params: data, token: token
-          expect(response).to have_http_status(201)
-          expect(Withdraw.last.sum.to_s).to eq data[:amount]
+          expect(response).to have_http_status(422)
+          expect(response).to include_api_error('account.beneficiary.doesnt_exist')
         end
       end
 
-      it 'validates missing params' do
-        data.except!(:otp, :rid, :amount, :currency)
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.missing_otp')
-        expect(response).to include_api_error('account.withdraw.missing_rid')
-        expect(response).to include_api_error('account.withdraw.missing_amount')
-        expect(response).to include_api_error('account.withdraw.missing_currency')
+      context 'pending' do
+        before { beneficiary.update(state: :pending) }
+        it do
+          api_post '/api/v2/account/withdraws', params: data, token: token
+          expect(response).to have_http_status(422)
+          expect(response).to include_api_error('account.beneficiary.invalid_state_for_withdrawal')
+        end
       end
+    end
 
-      it 'requires otp' do
-        data[:otp] = nil
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.empty_otp')
-      end
+    it 'requires beneficiary_id' do
+      data[:beneficiary_id] = nil
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.empty_beneficiary_id')
+    end
 
-      it 'validates otp code' do
-        Vault::TOTP.stubs(:validate?).returns(false)
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.invalid_otp')
-      end
+    it 'validates beneficiary_id type' do
+      data[:beneficiary_id] = 'beneficiary_id'
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.non_integer_beneficiary_id')
+    end
 
-      it 'requires amount' do
-        data[:amount] = nil
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.non_positive_amount')
-      end
+    it 'requires otp' do
+      data[:otp] = nil
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.empty_otp')
+    end
 
-      it 'validates negative amount' do
-        data[:amount] = -1
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.non_positive_amount')
-      end
+    it 'validates otp code' do
+      Vault::TOTP.stubs(:validate?).returns(false)
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.invalid_otp')
+    end
 
-      it 'validates enough balance' do
-        data[:amount] = 100
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.insufficient_balance')
-      end
+    it 'requires amount' do
+      data[:amount] = nil
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.non_positive_amount')
+    end
 
-      it 'validates type amount' do
-        data[:amount] = 'one'
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.non_decimal_amount')
-      end
+    it 'validates negative amount' do
+      data[:amount] = -1
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.non_positive_amount')
+    end
 
-      it 'requires rid' do
-        data[:rid] = nil
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.empty_rid')
-      end
+    it 'validates enough balance' do
+      data[:amount] = 100
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.insufficient_balance')
+    end
 
-      it 'requires currency' do
-        data[:currency] = nil
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.currency.doesnt_exist')
-      end
+    it 'validates amount type' do
+      data[:amount] = 'one'
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.non_decimal_amount')
+    end
 
-      it 'creates new withdraw and immediately submits it' do
-        api_post '/api/v2/account/withdraws', params: data, token: token
-        expect(response).to have_http_status(201)
-        record = Withdraw.last
-        expect(record.sum).to eq 0.1575
-        expect(record.aasm_state).to eq 'submitted'
-        expect(record.account).to eq account
-        expect(record.account.balance).to eq(1.2 - amount)
-        expect(record.account.locked).to eq amount
-      end
+    it 'validates amount precision' do
+      data[:amount] = 0.123456789123456789
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.invalid_amount')
+    end
 
-      it 'creates new withdraw with note' do
-        api_post '/api/v2/account/withdraws', params: data.merge(note: 'Test note'), token: token
-        expect(response).to have_http_status(201)
+    it 'requires currency' do
+      data[:currency] = nil
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.currency.doesnt_exist')
+    end
 
-        result = JSON.parse(response.body)
-        expect(result['note']).to eq 'Test note'
+    it 'disabled currency' do
+      data[:currency] = :eur
+      api_post '/api/v2/account/withdraws', params: data, token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.currency.doesnt_exist')
+    end
 
-        record = Withdraw.last
-        expect(record.note).to eq 'Test note'
-      end
+    it 'creates new withdraw and immediately submits it' do
+      api_post '/api/v2/account/withdraws', params: data, token: token
 
-      it 'doesnt create new withdraw with too long note' do
-        api_post '/api/v2/account/withdraws', params: data.merge(note: long_note), token: token
-        expect(response).to have_http_status(422)
-        expect(response).to include_api_error('account.withdraw.too_long_note')
-      end
+      expect(response).to have_http_status(201)
+      record = Withdraw.last
+      expect(record.sum).to eq amount
+      expect(record.aasm_state).to eq 'submitted'
+      expect(record.account).to eq account
+      expect(record.account.balance).to eq(1.2 - amount)
+      expect(record.account.locked).to eq amount
+    end
+
+    it 'creates new withdraw with note' do
+      api_post '/api/v2/account/withdraws', params: data.merge(note: 'Test note'), token: token
+      expect(response).to have_http_status(201)
+
+      result = JSON.parse(response.body)
+      expect(result['note']).to eq 'Test note'
+
+      record = Withdraw.last
+      expect(record.note).to eq 'Test note'
+    end
+
+    it 'doesnt create new withdraw with too long note' do
+      api_post '/api/v2/account/withdraws', params: data.merge(note: long_note), token: token
+      expect(response).to have_http_status(422)
+      expect(response).to include_api_error('account.withdraw.too_long_note')
     end
   end
 end

--- a/spec/factories/withdraw.rb
+++ b/spec/factories/withdraw.rb
@@ -19,6 +19,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_beneficiary do
+      beneficiary do
+        create(:beneficiary,
+               currency: currency,
+               member: member,
+               state: :active)
+      end
+      rid { nil }
+    end
+
     currency { Currency.find(:btc) }
     member { create(:member, :level_3) }
     rid { Faker::Blockchain::Bitcoin.address }
@@ -34,6 +44,16 @@ FactoryBot.define do
         create(:deposit_usd, member: withdraw.member, amount: withdraw.sum)
           .accept!
       end
+    end
+
+    trait :with_beneficiary do
+      beneficiary do
+        create(:beneficiary,
+               currency: currency,
+               member: member,
+               state: :active)
+      end
+      rid { nil }
     end
 
     member { create(:member, :level_3) }

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -116,6 +116,13 @@ module APITestHelpers
 
     Rails.configuration.x.security_configuration = config
   end
+
+  # TODO: Improvements:
+  #   - ability to use both symbol and string keys;
+  #   - handle nil response body;
+  def response_body
+    JSON.parse(response.body)
+  end
 end
 
 RSpec.configure { |config| config.include APITestHelpers }


### PR DESCRIPTION
Since we can store Beneficiaries in peatio starting from #2347 now we can implement user withdraw API for both fiat & crypto currencies. It means that in this patch we have replaced POST accounts/withdraw `rid` param with `beneficiary_id`. This change gives ability to use active beneficiaries for both fiat & crypto withdrawals.

`Beneficiary` is now exposed in Admin API as field of `Withdraw` so admin can validate it directly.

`beneficiary_id` foreign key was added to `Withdraw` model so now it has optional `belongs_to` association with `Beneficiary`.

Also this patch improves `Withdraw` `sum` & `amount` precision logic. Instead of rounding attributes on creation now attributes precision is validated on `Withdraw` creation.

This patch also adds additional validation for Beneficiary data attribute