### PR TITLE
Remove :touch_account after currency creation

### DIFF
--- a/app/api/v2/account/deposits.rb
+++ b/app/api/v2/account/deposits.rb
@@ -80,7 +80,7 @@ module API
             error!({ errors: ['account.currency.deposit_disabled'] }, 422)
           end
 
-          current_user.ac(currency).payment_address.yield_self do |pa|
+          current_user.get_account(currency).payment_address.yield_self do |pa|
             { currency: params[:currency], address: params[:address_format] ? pa.format_address(params[:address_format]) : pa.address }
           end
         end

--- a/app/api/v2/management/helpers.rb
+++ b/app/api/v2/management/helpers.rb
@@ -92,19 +92,19 @@ module API
         # @deprecated
         def credit_legacy_balance!(amount:, member:, currency:, account:)
           if account.kind.main?
-            member.ac(currency).plus_funds(amount)
+            member.get_account(currency).plus_funds(amount)
           elsif account.kind.locked?
-            member.ac(currency).plus_funds(amount)
-            member.ac(currency).lock_funds(amount)
+            member.get_account(currency).plus_funds(amount)
+            member.get_account(currency).lock_funds(amount)
           end
         end
 
         # @deprecated
         def debit_legacy_balance!(amount:, member:, currency:, account:)
           if account.kind.main?
-            member.ac(currency).sub_funds(amount)
+            member.get_account(currency).sub_funds(amount)
           elsif account.kind.locked?
-            member.ac(currency).unlock_and_sub_funds(amount)
+            member.get_account(currency).unlock_and_sub_funds(amount)
           end
         end
       end

--- a/app/api/v2/order_helpers.rb
+++ b/app/api/v2/order_helpers.rb
@@ -17,9 +17,7 @@ module API
       end
 
       def check_balance(order)
-        current_user.accounts
-                    .find_by_currency_id(order.currency)
-                    .balance >= order.locked
+        current_user.get_account(order.currency).balance >= order.locked
       end
 
       def create_order(attrs)

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -76,8 +76,6 @@ class Currency < ApplicationRecord
     self.erc20_contract_address = erc20_contract_address.try(:downcase) if erc20_contract_address.present?
   end
 
-  after_create { Member.find_each(&:touch_accounts) }
-
   after_update :disable_markets
 
   # == Class Methods ========================================================

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -69,7 +69,7 @@ class Deposit < ApplicationRecord
   end
 
   def account
-    member&.ac(currency)
+    member&.get_account(currency)
   end
 
   def uid

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -46,13 +46,14 @@ class Member < ApplicationRecord
   end
 
   def get_account(model_or_id_or_code)
-    accounts.with_currency(model_or_id_or_code).first.yield_self do |account|
-      touch_accounts unless account
-      accounts.with_currency(model_or_id_or_code).first
+    if model_or_id_or_code.is_a?(String) || model_or_id_or_code.is_a?(Symbol)
+      accounts.find_or_create_by(currency_id: model_or_id_or_code)
+    elsif model_or_id_or_code.is_a?(Currency)
+      accounts.find_or_create_by(currency: model_or_id_or_code)
     end
   end
-  alias :ac :get_account
 
+  # @deprecated
   def touch_accounts
     Currency.find_each do |currency|
       next if accounts.where(currency: currency).exists?
@@ -76,9 +77,9 @@ class Member < ApplicationRecord
 
   def legacy_balance_for(currency:, kind:)
     if kind.to_sym == :main
-      ac(currency).balance
+      get_account(currency).balance
     elsif kind.to_sym == :locked
-      ac(currency).locked
+      get_account(currency).locked
     else
       raise Operations::Exception, "Account for #{options} doesn't exists."
     end

--- a/app/models/operations.rb
+++ b/app/models/operations.rb
@@ -27,7 +27,7 @@ module Operations
       return unless liability.present? || liability.is_a?(Operations::Liability)
 
       account = liability.account
-      legacy_account = liability.member.accounts.find_or_create_by(currency: liability.currency)
+      legacy_account = liability.member.get_account(liability.currency)
 
       credit = liability.credit
       debit = liability.debit

--- a/app/models/withdraw.rb
+++ b/app/models/withdraw.rb
@@ -29,7 +29,7 @@ class Withdraw < ApplicationRecord
 
   acts_as_eventable prefix: 'withdraw', on: %i[create update]
 
-  before_validation(on: :create) { self.account ||= member&.ac(currency) }
+  before_validation(on: :create) { self.account ||= member&.get_account(currency) }
   before_validation(on: :create) { self.rid ||= beneficiary.rid if beneficiary.present? }
   before_validation { self.completed_at ||= Time.current if completed? }
 

--- a/app/trading/matching/executor.rb
+++ b/app/trading/matching/executor.rb
@@ -79,6 +79,10 @@ module Matching
           @taker_order = orders.find { |order| order.id == @trade_payload[:taker_order_id] }
         end
 
+        # Check if accounts exists or create them.
+        @maker_order.member.get_account(@maker_order.outcome_currency)
+        @taker_order.member.get_account(@taker_order.outcome_currency)
+
         validate!
 
         accounts_table = Account

--- a/spec/api/v2/account/deposits_spec.rb
+++ b/spec/api/v2/account/deposits_spec.rb
@@ -139,7 +139,7 @@ describe API::V2::Account::Deposits, type: :request do
     end
 
     context 'successful' do
-      before { member.ac(:bch).payment_address.update!(address: '2N2wNXrdo4oEngp498XGnGCbru29MycHogR') }
+      before { member.get_account(:bch).payment_address.update!(address: '2N2wNXrdo4oEngp498XGnGCbru29MycHogR') }
 
       xit 'doesn\'t expose sensitive data' do
         api_get "/api/v2/account/deposit_address/#{currency}", token: token

--- a/spec/api/v2/management/entities/balance_spec.rb
+++ b/spec/api/v2/management/entities/balance_spec.rb
@@ -3,7 +3,7 @@
 
 describe API::V2::Management::Entities::Balance do
   let(:member) { create(:member, :barong) }
-  let(:record) { member.ac(:usd) }
+  let(:record) { member.get_account(:usd) }
   before { record.update!(balance: 1000.85, locked: 330.55) }
   subject { OpenStruct.new API::V2::Management::Entities::Balance.represent(record).serializable_hash }
 

--- a/spec/api/v2/management/operations_spec.rb
+++ b/spec/api/v2/management/operations_spec.rb
@@ -307,7 +307,7 @@ describe API::V2::Management::Operations, type: :request do
 
           it 'updates legacy balance' do
             currency_id = JSON.parse(response.body)['currency']
-            expect(member.ac(currency_id).balance).to \
+            expect(member.get_account(currency_id).balance).to \
               eq JSON.parse(response.body)['credit'].to_d
           end
 
@@ -356,7 +356,7 @@ describe API::V2::Management::Operations, type: :request do
 
           it 'updates legacy balance' do
             currency_id = JSON.parse(response.body)['currency']
-            expect(member.ac(currency_id).balance).to \
+            expect(member.get_account(currency_id).balance).to \
               eq 0.to_d
           end
         end

--- a/spec/api/v2/management/transfers_spec.rb
+++ b/spec/api/v2/management/transfers_spec.rb
@@ -277,10 +277,10 @@ describe API::V2::Management::Transfers, type: :request do
       end
 
       it 'updates legacy balances' do
-        expect { request }.to change{ referrer1.ac(base_unit).balance }.by(0.0001 + 0.0003).and \
-                              change{ referrer2.ac(base_unit).balance }.by(0.00015).and \
-                              change{ referrer2.ac(quote_unit).balance }.by(0.05).and \
-                              change{ referrer3.ac(quote_unit).balance }.by(0.075)
+        expect { request }.to change{ referrer1.get_account(base_unit).balance }.by(0.0001 + 0.0003).and \
+                              change{ referrer2.get_account(base_unit).balance }.by(0.00015).and \
+                              change{ referrer2.get_account(quote_unit).balance }.by(0.05).and \
+                              change{ referrer3.get_account(quote_unit).balance }.by(0.075)
       end
 
       context 'wrong account code' do
@@ -424,8 +424,8 @@ describe API::V2::Management::Transfers, type: :request do
       end
 
       it 'updates legacy balance' do
-        expect { request }.to change{ member1.ac(coin).balance }.by(10).and \
-                              change{ member2.ac(coin).balance }.by(5)
+        expect { request }.to change{ member1.get_account(coin).balance }.by(10).and \
+                              change{ member2.get_account(coin).balance }.by(5)
       end
     end
   end

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -5,7 +5,7 @@ module AccountFactory
   def create_account(*arguments)
     currency   = Symbol === arguments.first ? arguments.first : :usd
     attributes = arguments.extract_options!
-    attributes.delete(:member) { create(:member) }.ac(currency).tap do |account|
+    attributes.delete(:member) { create(:member) }.get_account(currency).tap do |account|
       account.update!(attributes)
     end
   end

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
 
       # Update legacy balance.
       after(:create) do |liability|
-        acc = liability.member.ac(liability.currency)
+        acc = liability.member.get_account(liability.currency)
         acc.plus_funds(liability.credit) unless liability.credit.zero?
         acc.sub_funds(liability.debit) unless liability.debit.zero?
       end

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -621,7 +621,7 @@ describe Withdraw do
 
   context 'CashAddr' do
     let(:member) { create(:member) }
-    let(:account) { member.ac(:bch).tap { |x| x.update!(balance: 1.0.to_d) } }
+    let(:account) { member.get_account(:bch).tap { |x| x.update!(balance: 1.0.to_d) } }
     let :record do
       Withdraws::Coin.new \
         currency: Currency.find(:bch),
@@ -676,7 +676,7 @@ describe Withdraw do
 
   context 'validate note length' do
     let(:member)    { create(:member) }
-    let(:account)   { member.ac(:btc).tap { |x| x.update!(balance: 1.0.to_d) } }
+    let(:account)   { member.get_account(:btc).tap { |x| x.update!(balance: 1.0.to_d) } }
     let(:address)   { 'bitcoincash:qqkv9wr69ry2p9l53lxp635va4h86wv435995w8p2h' }
 
     let :record do

--- a/spec/serializers/serializers/event_api/order_canceled_spec.rb
+++ b/spec/serializers/serializers/event_api/order_canceled_spec.rb
@@ -26,8 +26,8 @@ describe Serializers::EventAPI::OrderCanceled do
   let(:canceled_at) { Time.current }
 
   before do
-    seller.ac(:btc).plus_funds('100.0'.to_d)
-    seller.ac(:btc).lock_funds('100.0'.to_d)
+    seller.get_account(:btc).plus_funds('100.0'.to_d)
+    seller.get_account(:btc).lock_funds('100.0'.to_d)
   end
 
   before { OrderAsk.any_instance.expects(:created_at).returns(created_at).at_least_once }

--- a/spec/serializers/serializers/event_api/order_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/order_completed_spec.rb
@@ -26,8 +26,8 @@ describe Serializers::EventAPI::OrderCompleted do
   let(:completed_at) { Time.current }
 
   before do
-    seller.ac(:btc).plus_funds('100.0'.to_d)
-    seller.ac(:btc).lock_funds('100.0'.to_d)
+    seller.get_account(:btc).plus_funds('100.0'.to_d)
+    seller.get_account(:btc).lock_funds('100.0'.to_d)
   end
 
   before { OrderAsk.any_instance.expects(:created_at).returns(created_at).at_least_once }

--- a/spec/serializers/serializers/event_api/order_created_spec.rb
+++ b/spec/serializers/serializers/event_api/order_created_spec.rb
@@ -25,8 +25,8 @@ describe Serializers::EventAPI::OrderCreated do
   let(:created_at) { Time.current }
 
   before do
-    buyer.ac(:btc).plus_funds('100.0'.to_d)
-    buyer.ac(:btc).lock_funds('100.0'.to_d)
+    buyer.get_account(:btc).plus_funds('100.0'.to_d)
+    buyer.get_account(:btc).lock_funds('100.0'.to_d)
   end
 
   before { OrderBid.any_instance.expects(:created_at).returns(created_at).at_least_once }

--- a/spec/serializers/serializers/event_api/order_updated_spec.rb
+++ b/spec/serializers/serializers/event_api/order_updated_spec.rb
@@ -26,8 +26,8 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
   let(:updated_at) { Time.current }
 
   before do
-    seller.ac(:btc).plus_funds('100.0'.to_d)
-    seller.ac(:btc).lock_funds('100.0'.to_d)
+    seller.get_account(:btc).plus_funds('100.0'.to_d)
+    seller.get_account(:btc).lock_funds('100.0'.to_d)
   end
 
   before { OrderAsk.any_instance.expects(:created_at).returns(created_at).at_least_once }
@@ -103,8 +103,8 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
   let(:updated_at) { Time.current }
 
   before do
-    buyer.ac(:btc).plus_funds('100.0'.to_d)
-    buyer.ac(:btc).lock_funds('100.0'.to_d)
+    buyer.get_account(:btc).plus_funds('100.0'.to_d)
+    buyer.get_account(:btc).lock_funds('100.0'.to_d)
   end
 
   before { OrderBid.any_instance.expects(:created_at).returns(created_at).at_least_once }

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -87,13 +87,13 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
     subject { executor.execute! }
 
     before do
-      maker.ac(:btc).plus_funds('100.0'.to_d)
-      maker.ac(:btc).lock_funds('100.0'.to_d)
+      maker.get_account(:btc).plus_funds('100.0'.to_d)
+      maker.get_account(:btc).lock_funds('100.0'.to_d)
     end
 
     before do
-      taker.ac(:usd).plus_funds('100.0'.to_d)
-      taker.ac(:usd).lock_funds('14.0'.to_d)
+      taker.get_account(:usd).plus_funds('100.0'.to_d)
+      taker.get_account(:usd).lock_funds('14.0'.to_d)
     end
 
     before { Trade.any_instance.expects(:created_at).returns(completed_at).at_least_once }
@@ -156,13 +156,13 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
     subject { executor.execute! }
 
     before do
-      taker.ac(:btc).plus_funds('100.0'.to_d)
-      taker.ac(:btc).lock_funds('100.0'.to_d)
+      taker.get_account(:btc).plus_funds('100.0'.to_d)
+      taker.get_account(:btc).lock_funds('100.0'.to_d)
     end
 
     before do
-      maker.ac(:usd).plus_funds('100.0'.to_d)
-      maker.ac(:usd).lock_funds('14.0'.to_d)
+      maker.get_account(:usd).plus_funds('100.0'.to_d)
+      maker.get_account(:usd).lock_funds('14.0'.to_d)
     end
 
     before { Trade.any_instance.expects(:created_at).returns(completed_at).at_least_once }

--- a/spec/services/wallet_service_spec.rb
+++ b/spec/services/wallet_service_spec.rb
@@ -43,7 +43,7 @@ describe WalletService do
   end
 
   context :create_address! do
-    let(:account) { create(:member, :level_3, :barong).ac(currency)  }
+    let(:account) { create(:member, :level_3, :barong).get_account(currency)  }
     let(:blockchain_address) do
       { address: :fake_address,
         secret: :changeme,

--- a/spec/workers/deposit_coin_address_spec.rb
+++ b/spec/workers/deposit_coin_address_spec.rb
@@ -3,7 +3,7 @@
 
 describe Workers::AMQP::DepositCoinAddress do
   let(:member) { create(:member, :barong) }
-  let(:account) { member.ac(:btc) }
+  let(:account) { member.get_account(:btc) }
   let(:address) { Faker::Blockchain::Bitcoin.address }
   let(:secret) { PasswordGenerator.generate(64) }
   let(:wallet) { Wallet.deposit.find_by(blockchain_key: 'btc-testnet') }


### PR DESCRIPTION
- [x] An API to create accounts and deposit address.
- [x] Create an account when needed on trade.
- [x] Remove `get_account - ac` alias