### PR TITLE
Feature: Tickers calculation from influxdb

### DIFF
--- a/app/api/v2/entities/trade.rb
+++ b/app/api/v2/entities/trade.rb
@@ -94,9 +94,7 @@ module API
             type: String,
             desc: 'Trade taker order type (sell or buy).'
           }
-        ) do |trade, _options|
-          trade.taker_order.side
-        end
+        )
 
         expose(
           :side,

--- a/db/migrate/20200228093038_add_taker_type_to_trade.rb
+++ b/db/migrate/20200228093038_add_taker_type_to_trade.rb
@@ -1,0 +1,16 @@
+class AddTakerTypeToTrade < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        add_column :trades, :taker_type, :string, limit: 20, after: :taker_id, null: false
+        Trade.find_each do |t|
+          t.update_attribute(:taker_type, t.taker_order.side)
+        end
+      end
+
+      dir.down do
+        remove_column :trades, :taker_type
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 2020_03_05_140516) do
     t.string "market_id", limit: 20, null: false
     t.integer "maker_id", null: false
     t.integer "taker_id", null: false
+    t.string "taker_type", limit: 20, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_trades_on_created_at"


### PR DESCRIPTION
- Rewrite market_ticker daemon with fetching trades from Influxdb;
- Add `taker_type` to Trade model + set `taker_type` in migration;
- Rewrite Global `h24_volume` and `avg_h24_price` from influx;
