### PR TITLE
Fix: Update UID and GID to the app user for all project files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 WORKDIR $APP_HOME
 
 # Install dependencies defined in Gemfile.
-COPY Gemfile Gemfile.lock $APP_HOME/
+COPY --chown=app:app Gemfile Gemfile.lock $APP_HOME/
 RUN mkdir -p /opt/vendor/bundle \
   && gem install bundler:2.0.2 \
   && chown -R app:app /opt/vendor $APP_HOME \
@@ -61,7 +61,7 @@ CMD ["bundle", "exec", "puma", "--config", "config/puma.rb"]
 FROM base
 
 # Copy Gemfile.plugin for installing plugins.
-COPY Gemfile.plugin Gemfile.lock $APP_HOME/
+COPY --chown=app:app Gemfile.plugin Gemfile.lock $APP_HOME/
 
 # Install plugins.
 RUN bundle install --path /opt/vendor/bundle

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -2,7 +2,7 @@
 FROM rubykube/peatio:latest
 
 # Copy Gemfile.plugin for installing plugins.
-COPY Gemfile.plugin $APP_HOME
+COPY --chown=app:app Gemfile.plugin $APP_HOME
 
 # Install plugins.
 RUN bundle install --path /opt/vendor/bundle


### PR DESCRIPTION
This will fix the permission issue people are having when building plugins from the base image based of your documentation.

<https://github.com/openware/peatio/blob/master/docs/plugins.md#peatio-plugin-api-v2>

closes #2423