### PR TITLE
Fix: add ability to cancel order by uuid

### DIFF
--- a/app/api/v2/market/orders.rb
+++ b/app/api/v2/market/orders.rb
@@ -108,7 +108,13 @@ module API
         end
         post '/orders/:id/cancel' do
           begin
-            order = current_user.orders.find(params[:id])
+            if params[:id].match?(/\A[0-9]+\z/)
+              order = current_user.orders.find_by!(id: params[:id])
+            elsif UUID.validate(params[:id])
+              order = current_user.orders.find_by!(uuid: params[:id])
+            else
+              error!({ errors: ['market.order.invaild_id_or_uuid'] }, 422)
+            end
             cancel_order(order)
             present order, with: API::V2::Entities::Order
           rescue ActiveRecord::RecordNotFound => e


### PR DESCRIPTION
baseapp cancel an order by UUID but endpoint does not support that. This PR fix it.

## test
```
Run options: include {:full_description=>/POST\ \/api\/v2\/market\/orders\/:id\/cancel/}

Randomized with seed 51938
...

Finished in 1.25 seconds (files took 1.79 seconds to load)
3 examples, 0 failures

Randomized with seed 51938
```