### PR TITLE
Fix: Avoid to use join in admin API for tables with a large amount of data. Change Kaminari usage in pagination

### DIFF
--- a/app/api/v2/admin/operations.rb
+++ b/app/api/v2/admin/operations.rb
@@ -71,10 +71,11 @@ module API
             klass = ::Operations.const_get(op_type.capitalize)
             authorize! :read, klass
 
-            search = klass.ransack(ransack_params.merge(member_uid_eq: params[:uid]))
+            member = Member.find_by(uid: params[:uid]) if params[:uid].present?
+            search = klass.ransack(ransack_params.merge(member_id_eq: member&.id))
             search.sorts = "#{params[:order_by]} #{params[:ordering]}"
 
-            present paginate(search.result), with: API::V2::Admin::Entities::Operation
+            present paginate(search.result, false), with: API::V2::Admin::Entities::Operation
           end
         end
       end

--- a/app/api/v2/admin/trades.rb
+++ b/app/api/v2/admin/trades.rb
@@ -29,11 +29,13 @@ module API
         get '/trades' do
           authorize! :read, Trade
 
-          ransack_params = Helpers::RansackBuilder.new(params)
+          member = Member.find_by(uid: params[:uid]) if params[:uid].present?
+
+          ransack_params = Helpers::RansackBuilder.new(params.except!(:uid))
                              .translate(market: :market_id)
                              .with_daterange
                              .merge(g: [
-                               { maker_uid_eq: params[:uid], taker_uid_eq: params[:uid], m: 'or' },
+                               { maker_id_eq: member&.id, taker_id_eq: member&.id, m: 'or' },
                                { maker_order_id_eq: params[:order_id], taker_order_id_eq: params[:order_id], m: 'or' },
                              ]).build
 

--- a/app/api/v2/helpers.rb
+++ b/app/api/v2/helpers.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 module API
@@ -19,11 +18,13 @@ module API
       def set_ets_context!
         return unless defined?(Raven)
 
-        Raven.user_context(
-          email: current_user.email,
-          uid: current_user.uid,
-          role: current_user.role
-        ) if current_user
+        if current_user
+          Raven.user_context(
+            email: current_user.email,
+            uid: current_user.uid,
+            role: current_user.role
+          )
+        end
         Raven.tags_context(
           peatio_version: Peatio::Application::VERSION
         )
@@ -58,9 +59,9 @@ module API
         if request.env.key?('jwt.payload')
           begin
             Member.from_payload(request.env['jwt.payload'].symbolize_keys)
-              # Handle race conditions when creating member record.
-              # We do not handle race condition for update operations.
-              # http://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by
+          # Handle race conditions when creating member record.
+          # We do not handle race condition for update operations.
+          # http://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by
           rescue ActiveRecord::RecordNotUnique
             retry
           end
@@ -79,7 +80,7 @@ module API
 
         # Add vol for compatibility with old API.
         formatted_ticker = ticker.slice(*permitted_keys)
-                             .merge(vol: ticker[:volume])
+                                 .merge(vol: ticker[:volume])
         { at: ticker[:at],
           ticker: formatted_ticker }
       end
@@ -88,7 +89,12 @@ module API
         per_page = params[:limit] || Kaminari.config.default_per_page
         per_page = [per_page.to_i, Kaminari.config.max_per_page].compact.min
 
-        Kaminari.paginate_array(collection).page(params[:page].to_i).per(per_page).tap do |data|
+        result = if collection.is_a?(::ActiveRecord::Relation)
+                   collection.page(params[:page].to_i).per(per_page)
+                 elsif collection.is_a?(Array)
+                   Kaminari.paginate_array(collection).page(params[:page].to_i).per(per_page)
+                 end
+        result.tap do |data|
           header 'Total',       data.total_count.to_s if include_total
           header 'Per-Page',    data.limit_value.to_s
           header 'Page',        data.current_page.to_s

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -334,4 +334,5 @@ end
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
 #  index_orders_on_updated_at                    (updated_at)
+#  index_orders_on_uuid                          (uuid) UNIQUE
 #

--- a/app/models/order_ask.rb
+++ b/app/models/order_ask.rb
@@ -94,4 +94,5 @@ end
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
 #  index_orders_on_updated_at                    (updated_at)
+#  index_orders_on_uuid                          (uuid) UNIQUE
 #

--- a/app/models/order_bid.rb
+++ b/app/models/order_bid.rb
@@ -99,4 +99,5 @@ end
 #  index_orders_on_type_and_state_and_market_id  (type,state,market_id)
 #  index_orders_on_type_and_state_and_member_id  (type,state,member_id)
 #  index_orders_on_updated_at                    (updated_at)
+#  index_orders_on_uuid                          (uuid) UNIQUE
 #

--- a/db/migrate/20200513153429_add_uuid_index_for_orders.rb
+++ b/db/migrate/20200513153429_add_uuid_index_for_orders.rb
@@ -1,0 +1,5 @@
+class AddUUIDIndexForOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_index :orders, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -236,6 +236,7 @@ ActiveRecord::Schema.define(version: 2020_05_27_130534) do
     t.index ["type", "state", "market_id"], name: "index_orders_on_type_and_state_and_market_id"
     t.index ["type", "state", "member_id"], name: "index_orders_on_type_and_state_and_member_id"
     t.index ["updated_at"], name: "index_orders_on_updated_at"
+    t.index ["uuid"], name: "index_orders_on_uuid", unique: true
   end
 
   create_table "payment_addresses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
* Fix: Avoid to use join in admin API for tables with large amount of data

* Add index for orders on uuid