### PR TITLE
2-5-stable:  bitcoin & ethereum json client: pass endpoint path if provided

### DIFF
--- a/lib/peatio/bitcoin/client.rb
+++ b/lib/peatio/bitcoin/client.rb
@@ -14,12 +14,13 @@ module Bitcoin
 
     def initialize(endpoint, idle_timeout: 5)
       @json_rpc_endpoint = URI.parse(endpoint)
+      @path = @json_rpc_endpoint.path.empty? ? "/" : @json_rpc_endpoint.path
       @idle_timeout = idle_timeout
     end
 
     def json_rpc(method, params = [])
       response = connection.post \
-        '/',
+        @path,
         {jsonrpc: '1.0', method: method, params: params}.to_json,
         {'Accept' => 'application/json',
          'Content-Type' => 'application/json'}

--- a/lib/peatio/ethereum/client.rb
+++ b/lib/peatio/ethereum/client.rb
@@ -15,12 +15,13 @@ module Ethereum
     def initialize(endpoint, idle_timeout: 5)
       @json_rpc_endpoint = URI.parse(endpoint)
       @json_rpc_call_id = 0
+      @path = @json_rpc_endpoint.path.empty? ? "/" : @json_rpc_endpoint.path
       @idle_timeout = idle_timeout
     end
 
     def json_rpc(method, params = [])
       response = connection.post \
-          '/',
+          @path,
           {jsonrpc: '2.0', id: rpc_call_id, method: method, params: params}.to_json,
           {'Accept' => 'application/json',
            'Content-Type' => 'application/json'}

--- a/spec/lib/bitcoin/wallet_spec.rb
+++ b/spec/lib/bitcoin/wallet_spec.rb
@@ -31,6 +31,9 @@ describe Bitcoin::Wallet do
     let(:uri) { 'http://user:password@127.0.0.1:18332' }
     let(:uri_without_authority) { 'http://127.0.0.1:18332' }
 
+    let(:uri_with_wallet) { 'http://user:password@127.0.0.1:18332/wallet/testwallet' }
+    let(:uri_with_wallet_no_authority) { 'http://127.0.0.1:18332/wallet/testwallet' }
+
     let(:settings) do
       {
         wallet:
@@ -54,6 +57,25 @@ describe Bitcoin::Wallet do
                            error:  nil,
                            id:     nil }.to_json)
 
+      result = wallet.create_address!(uid: 'UID123')
+      expect(result.as_json.symbolize_keys).to eq(address: address)
+    end
+
+    it 'works with wallet path' do
+      wallet.configure({
+        wallet: {
+          address: 'something',
+          uri:     uri_with_wallet },
+        currency: {}
+      })
+      address = '2N4qYjye5yENLEkz4UkLFxzPaxJatF3kRwf'
+      stub_request(:post, uri_with_wallet_no_authority)
+        .with(body: { jsonrpc: '1.0',
+                      method: :getnewaddress,
+                      params:  [] }.to_json)
+        .to_return(body: { result: address,
+                           error:  nil,
+                           id:     nil }.to_json)
       result = wallet.create_address!(uid: 'UID123')
       expect(result.as_json.symbolize_keys).to eq(address: address)
     end

--- a/spec/lib/ethereum/wallet_spec.rb
+++ b/spec/lib/ethereum/wallet_spec.rb
@@ -29,6 +29,7 @@ describe Ethereum::Wallet do
     end
 
     let(:uri) { 'http://127.0.0.1:8545' }
+    let(:uri_with_path) { 'http://127.0.0.1:8545/path/extra' }
 
     let(:settings) do
       {
@@ -54,6 +55,27 @@ describe Ethereum::Wallet do
         .to_return(body: { jsonrpc: '2.0',
                            result: address,
                            id:     1 }.to_json)
+
+      result = wallet.create_address!(uid: 'UID123')
+      expect(result.as_json.symbolize_keys).to eq(address: address, secret: 'pass@word')
+    end
+
+    it 'works with wallet path' do
+      wallet.configure({
+                               wallet:
+                                 { address: 'something',
+                                   uri:     uri_with_path },
+                               currency: {}
+                             })
+      address = '0x6d6cabaa7232d7f45b143b445114f7e92350a2aa'
+       stub_request(:post, uri_with_path)
+              .with(body: { jsonrpc: '2.0',
+                            id:     1,
+                            method: :personal_newAccount,
+                            params:  ['pass@word'] }.to_json)
+              .to_return(body: { jsonrpc: '2.0',
+                                 result: address,
+                                 id:     1 }.to_json)
 
       result = wallet.create_address!(uid: 'UID123')
       expect(result.as_json.symbolize_keys).to eq(address: address, secret: 'pass@word')


### PR DESCRIPTION
(#2541)

* bitcoin json client: pass endpoint path if provided

* ethereum json client: pass endpoint path if provided

* bitcoin & ethereum wallet_spec: test use of wallet with uri path