### PR TITLE
Fix flaky test of Beneficiary#sent_at generation

### DIFF
--- a/spec/models/beneficiary_spec.rb
+++ b/spec/models/beneficiary_spec.rb
@@ -100,10 +100,12 @@ describe Beneficiary, 'Callback' do
   context 'before_create' do
     subject { build(:beneficiary) }
     it 'generates sent_at' do
-      expect(subject.sent_at).to be_nil
-      subject.save!
-      expect(subject.sent_at).to_not be_nil
-      expect(subject.sent_at.round).to eq(subject.created_at.round)
+      Timecop.freeze do
+        expect(subject.sent_at).to be_nil
+        subject.save!
+        expect(subject.sent_at).to_not be_nil
+        expect(subject.sent_at).to eq(subject.created_at)
+      end
     end
   end
 end


### PR DESCRIPTION
Some times we have:

```                                                                                                                                      
Failures:                                                                                                                                     
                                                                                                                                    
  1) Beneficiary Callback before_create generates sent_at                                                                         
     Failure/Error: expect(subject.sent_at.round).to eq(subject.created_at.round)                                                  
                                                                                                                                                         
       expected: 2021-02-18 14:22:30.000000000 +0000                                                                                                        
            got: 2021-02-18 14:22:29.000000000 +0000                                                                               
                                                                                                                                                   
       (compared using ==)                                                                                                             
                                                                                                                                                   
       Diff:                                                                                                                                   
       @@ -1 +1 @@                                                                                                                            
       -Thu, 18 Feb 2021 14:22:30 UTC +00:00                                                                                          
       +Thu, 18 Feb 2021 14:22:29 UTC +00:00                                                                                            
                                                                                                                                                   
     # ./spec/models/beneficiary_spec.rb:115:in `block (3 levels) in <main>'                                                                                                  
                                                                                                                                                  
Finished in 18.29 seconds (files took 1.88 seconds to load)                            
```

Using `Timecop.freeze` instead of timestamp rounding fixes it.