### PR TITLE
Feature: Pluggable webhook endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'jwt-multisig', '~> 1.0.0'
 gem 'cash-addr', '~> 0.2.0', require: 'cash_addr'
 gem 'digest-sha3', '~> 1.1.0'
 gem 'scout_apm', '~> 2.4', require: false
-gem 'peatio', '~> 2.6.2'
+gem 'peatio', '~> 2.6.3'
 gem 'irix', '~> 2.6.0'
 gem 'rack-cors', '~> 1.0.6', require: false
 gem 'jwt-rack', '~> 0.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       railties (>= 4.2.0)
     faker (1.9.6)
       i18n (>= 0.7)
-    faraday (0.17.3)
+    faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
@@ -263,7 +263,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
-    peatio (2.6.2)
+    peatio (2.6.3)
       activemodel (> 5.2, <= 6.0.0)
       amqp
       bunny
@@ -505,7 +505,7 @@ DEPENDENCIES
   mocha (~> 1.8)
   mysql2 (~> 0.5.2)
   net-http-persistent (~> 3.0.1)
-  peatio (~> 2.6.2)
+  peatio (~> 2.6.3)
   peatio-bitcoincash (~> 2.6.1)
   peatio-bitgo (~> 2.6.3)
   peatio-dash (~> 2.6.1)

--- a/app/api/v2/management/entities/deposit.rb
+++ b/app/api/v2/management/entities/deposit.rb
@@ -6,7 +6,6 @@ module API
     module Management
       module Entities
         class Deposit < Base
-          expose :id, documentation: { type: Integer, desc: 'Deposit ID.' }
           expose :tid, documentation: { type: Integer, desc: 'The shared transaction ID.' }
           expose :currency_id, as: :currency, documentation: { type: String, desc: 'The currency code.' }
           expose :address, documentation: { type: String, desc: 'The deposit address.' }

--- a/app/api/v2/public/webhooks.rb
+++ b/app/api/v2/public/webhooks.rb
@@ -18,11 +18,11 @@ module API
         end
         # e.g. /webhooks/bitgo/deposit
         post '/webhooks/:adapter/:event' do
-          process_webhook_event(params, request.headers)
+          process_webhook_event(request)
           status 200
         rescue StandardError => e
           Rails.logger.warn { "Cannot perform webhook: #{params}. Error: #{e}." }
-          body errors: ["public.webhook.cannot_perfom_#{params['type']}"]
+          body errors: ["public.webhook.cannot_perfom_#{params['adapter']}_#{params['event']}"]
           status 422
         end
       end

--- a/app/api/v2/public/webhooks.rb
+++ b/app/api/v2/public/webhooks.rb
@@ -6,42 +6,18 @@ module API
       class Webhooks < Grape::API
         helpers ::API::V2::WebhooksHelpers
 
-        desc 'Bitgo Webhook'
+        desc 'Webhook controller'
         params do
+          requires :adapter,
+                   type: String,
+                   desc: 'Name of adapter for process webhook'
           requires :event,
                    type: String,
                    desc: 'Name of event can be deposit or withdraw',
                    values: { value: -> { %w[deposit withdraw] }, message: 'public.webhook.invalid_event' }
-          requires :type,
-                   type: String,
-                   desc: 'Type of event.'
-          given type: ->(val) { val == 'transfer' } do
-            requires :hash,
-                     type: String,
-                     desc: 'Transfer txid.'
-            requires :transfer,
-                     type: String,
-                     desc: 'Transfer id.'
-            requires :coin,
-                     type: String,
-                     desc: 'Currency code.'
-            requires :wallet,
-                     type: String,
-                     desc: 'Wallet id.'
-          end
-          given type: ->(val) { val == 'address_confirmation' } do
-            requires :hash,
-                     type: String,
-                     desc: 'Address txid.'
-            requires :address,
-                     type: String,
-                     desc: 'User Address.'
-            requires :walletId,
-                     type: String,
-                     desc: 'Wallet id.'
-          end
         end
-        post '/webhooks/:event' do
+        # e.g. /webhooks/bitgo/deposit
+        post '/webhooks/:adapter/:event' do
           proces_webhook_event(params)
           status 200
         rescue StandardError => e

--- a/app/api/v2/public/webhooks.rb
+++ b/app/api/v2/public/webhooks.rb
@@ -14,7 +14,7 @@ module API
           requires :event,
                    type: String,
                    desc: 'Name of event can be deposit or withdraw',
-                   values: { value: -> { %w[deposit withdraw] }, message: 'public.webhook.invalid_event' }
+                   values: { value: -> { %w[deposit withdraw deposit_address] }, message: 'public.webhook.invalid_event' }
         end
         # e.g. /webhooks/bitgo/deposit
         post '/webhooks/:adapter/:event' do

--- a/app/api/v2/public/webhooks.rb
+++ b/app/api/v2/public/webhooks.rb
@@ -18,7 +18,7 @@ module API
         end
         # e.g. /webhooks/bitgo/deposit
         post '/webhooks/:adapter/:event' do
-          proces_webhook_event(params)
+          process_webhook_event(params, request.headers)
           status 200
         rescue StandardError => e
           Rails.logger.warn { "Cannot perform webhook: #{params}. Error: #{e}." }

--- a/app/api/v2/public/webhooks.rb
+++ b/app/api/v2/public/webhooks.rb
@@ -5,6 +5,8 @@ module API
     module Public
       class Webhooks < Grape::API
         helpers ::API::V2::WebhooksHelpers
+        content_type :json, 'application/json'
+        content_type :txt, 'text/plain'
 
         desc 'Webhook controller'
         params do

--- a/app/api/v2/webhooks_helpers.rb
+++ b/app/api/v2/webhooks_helpers.rb
@@ -56,6 +56,15 @@ module API
           next if payment_address.blank?
 
           Rails.logger.info { "Deposit transaction detected: #{transaction.inspect}" }
+
+          if transaction.options.present? && transaction.options[:tid].present?
+            deposit = Deposits::Coin.find_by(tid: transaction.options[:tid])
+            if deposit.present? && deposit.txid.blank?
+              deposit.txid = transaction.hash
+              deposit.save!
+            end
+          end
+
           deposit =
             Deposits::Coin.find_or_create_by!(
               currency_id: transaction.currency_id,

--- a/app/api/v2/webhooks_helpers.rb
+++ b/app/api/v2/webhooks_helpers.rb
@@ -94,8 +94,12 @@ module API
               d.block_number = transaction.block_number
             end
           # TODO: check if block number changed.
-          next unless transaction.status.success?
-          deposit.accept!
+
+          if transaction.status.success?
+            deposit.accept!
+          elsif transaction.status.rejected?
+            deposit.reject!
+          end
           deposit
         end
       end
@@ -124,6 +128,8 @@ module API
             withdrawal.fail!
           elsif transaction.status.success?
             withdrawal.success!
+          elsif transaction.status.rejected?
+            withdrawal.reject!
           end
         end
       end

--- a/app/api/v2/webhooks_helpers.rb
+++ b/app/api/v2/webhooks_helpers.rb
@@ -106,8 +106,8 @@ module API
             withdraw = Withdraws::Coin.find_by(tid: transaction.options[:tid])
             if withdraw.present? && withdraw.txid.blank?
               withdraw.txid = transaction.hash
-              withdraw.dispatch!
               withdraw.save!
+              withdraw.dispatch!
             end
           end
 

--- a/app/services/wallet_service.rb
+++ b/app/services/wallet_service.rb
@@ -60,7 +60,8 @@ class WalletService
   def collect_deposit!(deposit, deposit_spread)
     @adapter.configure(wallet:   @wallet.to_wallet_api_settings,
                        currency: deposit.currency.to_blockchain_api_settings)
-    pa = deposit.member.payment_address(@wallet.id)
+
+    pa = PaymentAddress.find_by(wallet_id: @wallet.id, member: deposit.member, address: deposit.address)
     # NOTE: Deposit wallet configuration is tricky because wallet UIR
     #       is saved on Wallet model but wallet address and secret
     #       are saved in PaymentAddress.
@@ -129,9 +130,8 @@ class WalletService
   end
 
   def trigger_webhook_event(event)
-    currency = Currency.find(event[:coin])
     @adapter.configure(wallet:   @wallet.to_wallet_api_settings,
-                       currency: currency.to_blockchain_api_settings)
+                       currency: @wallet.currencies.first.to_blockchain_api_settings)
     @adapter.trigger_webhook_event(event)
   end
 

--- a/docs/airdrop.md
+++ b/docs/airdrop.md
@@ -28,7 +28,7 @@ curl -X POST -F 'file=@spec/resources/airdrops/airdrop.csv' 'https://opendax.clo
 
 ### Rules and exceptions
 
-1. Admin who received deposit for the airdrop total amount shouldV process airdrop from HIS user. Example:
+1. Admin who received deposit for the airdrop total amount should process airdrop from HIS user. Example:
     - Admin with uid ID1000001 received 300 usdt on his deposit account.
     - Admin with uid ID1000001 login and load csv in airdrop tab.
     - Airdrop API will take this user as src account and distribute funds from this account.

--- a/docs/peatio/opendax_cloud_plugin.md
+++ b/docs/peatio/opendax_cloud_plugin.md
@@ -1,0 +1,35 @@
+##  Opendax Cloud plugin
+
+This service is used in Openfinex microservice to generate wallets, sign and broadcast transactions
+
+### Authorization
+You should have two required env variables in peatio to make this plugin work
+- `PLATFORM_ID` - will be saved automatically on platform creation API call
+- `PEATIO_JWT_PRIVATE_KEY` - peatio private key
+
+### Settings configuration
+Here the most important configuration for wallet configurations
+
+Deposit/Hot wallet
+
+```json
+gateway: field set as `opendax_cloud`
+settings:
+  uri: a link to openfinex (e.g. "https://#{domain_name}/api/v2/opx/peatio")
+```
+
+#### Implemented functions are
+1. **Create address**
+For address creating you need to be sure that your deposit wallet has right configuration:
+- `blockchain_key` should be some  blockchain with right explorer_address, explorer_transaction which you use for your currency configuration too
+- `gateway` field set as `opendax_cloud`
+- in wallet settings you have:
+  - `uri` should be a link to openfinex cloud, default is `https://#{domain_name}/api/v2/opx/peatio`
+
+2. **Create transaction**
+3. **Load balance**
+Be sure you have correct address in deposit/hot wallet configuration
+
+4. **Trigger webhook event**
+
+This method requires `OPENFINEX_CLOUD_PUBLIC_KEY` env variable which will be used to decode request body from JWT (algorithm 'ES256') and return a list of transactions.

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -63,13 +63,23 @@ module OpendaxCloud
         currency_id: payload[:currency],
         amount: payload[:amount],
         hash: payload[:blockchain_txid],
-        to_address: payload[:rid],
+        to_address: payload[:rid] || payload[:address], # if there is no rid field, it means we have deposit
         txout: 0,
         status: payload[:state],
         options: {
           tid: payload[:tid]
         }
       )
+    rescue OpendaxCloud::Client::Error => e
+      raise Peatio::Wallet::ClientError, e
+    end
+
+    def check_authorization_headers(headers)
+      if headers['Authorization']
+        token = headers['Authorization'].split(' ').last
+
+        JWT.decode(token, ENV['OPENFINEX_CLOUD_PUBLIC_KEY'], true, { algorithm: 'RS256' })
+      end
     rescue OpendaxCloud::Client::Error => e
       raise Peatio::Wallet::ClientError, e
     end

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -56,6 +56,24 @@ module OpendaxCloud
       raise Peatio::Wallet::ClientError, e
     end
 
+    def trigger_webhook_event(payload)
+      payload = JSON.parse(payload).with_indifferent_access
+
+      Peatio::Transaction.new(
+        currency_id: payload[:currency],
+        amount: payload[:amount],
+        hash: payload[:blockchain_txid],
+        to_address: payload[:rid],
+        txout: 0,
+        status: payload[:state],
+        options: {
+          tid: payload[:tid]
+        }
+      )
+    rescue OpendaxCloud::Client::Error => e
+      raise Peatio::Wallet::ClientError, e
+    end
+
     def currency_id
       @currency.fetch(:id)
     end

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -6,7 +6,7 @@ module OpendaxCloud
     DEPOSIT_TRANSACTION_STATE_TRANSLATIONS = {
       success: %w[collected],
       rejected: %w[rejected],
-      pending: %w[processing accepted aml_processing aml_suspicious fee_processing]
+      pending: %w[processing fee_processing accepted]
     }.freeze
 
     WITHDRAW_TRANSACTION_STATE_TRANSLATIONS = {
@@ -48,10 +48,10 @@ module OpendaxCloud
 
     def create_transaction!(transaction)
       response = client.rest_api(:post, '/tx/send', {
-                        currency_id: currency_id,
-                        to_address: transaction.to_address,
-                        amount: transaction.amount,
-                        tid: transaction.options.try(:tid)
+                    currency_id: currency_id,
+                    to_address: transaction.to_address,
+                    amount: transaction.amount,
+                    tid: transaction.options.try(:[], :tid)
                   }.compact)
       transaction.options = response['options']
       transaction

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -49,9 +49,9 @@ module OpendaxCloud
     def create_transaction!(transaction)
       response = client.rest_api(:post, '/tx/send', {
                         currency_id: currency_id,
-                        to: transaction.to_address,
+                        to_address: transaction.to_address,
                         amount: transaction.amount,
-                        options: transaction.options
+                        tid: transaction.options[:tid]
                       })
       transaction.options = response['options']
       transaction

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -75,18 +75,15 @@ module OpendaxCloud
       # Verify JWT signature
       params = JWT.decode(request.body.string, public_key, true, { algorithm: 'ES256' }).first.with_indifferent_access
 
-      event = request.params[:event]
-      amount = event == 'deposit' ? convert_from_base_unit(params[:amount]) : params[:amount].to_d
-
       [
         Peatio::Transaction.new(
           currency_id: params[:currency],
-          amount: amount,
+          amount: params[:amount].to_d,
           hash: params[:blockchain_txid],
           # If there is no rid field, it means we have deposit in payload
           to_address: params[:rid] || params[:address],
           txout: 0,
-          status: translate_state(event, params[:state]),
+          status: translate_state(request.params[:event], params[:state]),
           options: {
             tid: params[:tid]
           })

--- a/lib/peatio/opendax_cloud/wallet.rb
+++ b/lib/peatio/opendax_cloud/wallet.rb
@@ -51,8 +51,8 @@ module OpendaxCloud
                         currency_id: currency_id,
                         to_address: transaction.to_address,
                         amount: transaction.amount,
-                        tid: transaction.options[:tid]
-                      })
+                        tid: transaction.options.try(:tid)
+                  }.compact)
       transaction.options = response['options']
       transaction
     rescue OpendaxCloud::Client::Error => e

--- a/spec/api/v2/public/webhooks.rb
+++ b/spec/api/v2/public/webhooks.rb
@@ -1,191 +1,221 @@
 # frozen_string_literal: true
 
 describe API::V2::Public::Webhooks, type: :request do
-  describe 'GET /webhooks/:event' do
-
+  describe 'GET /webhooks/:adapter/:event' do
     let(:member) { create(:member) }
 
-    let(:transaction) do
-      Peatio::Transaction.new(
-        currency_id: :eth,
-        hash: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-        amount: 0.5,
-        to_address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84',
-        block_number: 16880960,
-        txout: 0,
-        status: :success
-      )
-    end
+    context 'deposit' do
+      context 'deposit wallet doesnt exist' do
+        let(:params) do
+          {
+            adapter: 'opendax_cloud',
+            event: 'deposit'
+          }
+        end
 
-    let(:invlaid_transaction) do
-      Peatio::Transaction.new(
-        currency_id: :eth,
-        hash: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-        amount: 0.5,
-        to_address: '0x1ef338196bd0207ba4852ba7a6847eed59331b85',
-        block_number: 16880960,
-        txout: 0
-      )
-    end
+        it do
+          expect {
+            api_post '/api/v2/public/webhooks/opendax_cloud/deposit'
+          }.not_to change { Deposit.count }
 
-    let!(:wallet) { create(:wallet, :eth_deposit, name: 'Bitgo Deposit',
-                          gateway: :bitgo, settings:
-                          { uri: 'http://localhost',
-                            secret: 'changeme',
-                            wallet_id: '5e4d43680f39a6710435b74edba4e2c2',
-                            access_token: 'changeme',
-                            testnet: false }) }
-
-    let(:request_body) {
-      { 'event' => 'deposit',
-        'id' => '5e539be5e6715b2006c7bfa6278aa3f4',
-        'type' => 'transfer',
-        'wallet' => '5e4d43680f39a6710435b74edba4e2c2',
-        'url' => 'http://localhost.com',
-        'hash' => '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-        'coin' => 'eth',
-        'transfer' => '5e4e824894d4902c060f20c28b161fa8',
-        'state' => 'new',
-        'simulation' => 'true',
-        'retries' => '0',
-        'webhook' => '5e5399ddda65833f06cd53429bcbca83',
-        'updatedAt' => '2020-02-24T09:48:21.795Z',
-        'version' => '2' }
-    }
-
-
-    context 'nonexistent wallet' do
-      let(:request_body) {
-        { 'event' => 'deposit',
-          'id' => '5e539be5e6715b2006c7bfa6278aa3f4',
-          'type' => 'transfer',
-          'wallet' => 'changeme',
-          'url' => 'http://localhost.com',
-          'hash' => '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-          'coin' => 'eth',
-          'transfer' => '5e4e824894d4902c060f20c28b161fa8',
-          'state' => 'new',
-          'simulation' => 'true',
-          'retries' => '0',
-          'webhook' => '5e5399ddda65833f06cd53429bcbca83',
-          'updatedAt' => '2020-02-24T09:48:21.795Z',
-          'version' => '2' }
-      }
-
-      it 'doesnt create deposit and return 200' do
-        expect do
-          api_post '/api/v2/public/webhooks/deposit', params: request_body
-
-          expect(response.status).to eq 200
-        end.not_to change { Deposit.count }
-      end
-    end
-
-    context 'valid webhook callback' do
-
-      before do
-        member.get_account(:eth).payment_addresses.create(currency_id: :eth, address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84')
-        WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).returns({ transfers: [transaction] })
-      end
-
-      it 'creates new deposit' do
-        api_post '/api/v2/public/webhooks/deposit', params: request_body
-
-        expect(response.status).to eq 200
-        expect(Deposit.last.txid).to eq('0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac')
-      end
-
-      context 'process second time' do
-
-        it 'doesnt create deposit for same transfer' do
-          api_post '/api/v2/public/webhooks/deposit', params: request_body
-          expect do
-            api_post '/api/v2/public/webhooks/deposit', params: request_body
-
-            expect(response.status).to eq 200
-            expect(Deposit.last.txid).to eq('0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac')
-          end.not_to change { Deposit.count }
+          expect(Wallet.where(status: :active, kind: :deposit, gateway: params[:adapter]).count).to eq 0
         end
       end
 
-      context 'process undefined transfer' do
+      context 'deposit wallet exist' do
+        let!(:deposit_wallet) { create(:wallet, :eth_opendax_cloud_deposit) }
 
-        before do
-          WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).returns({ transfers: [invlaid_transaction] })
-        end
+        context 'transactions doesnt exist' do
+          let(:params) do
+            {
+              adapter: 'opendax_cloud',
+              event: 'deposit'
+            }
+          end
 
-        it 'doesnt create deposit and return 200' do
-          expect do
-            api_post '/api/v2/public/webhooks/deposit', params: request_body
-
-            expect(response.status).to eq 200
-          end.not_to change { Deposit.count }
-        end
-      end
-    end
-
-    context 'adapter raises error invalid' do
-
-      before do
-        member.get_account(:eth).payment_addresses.create(currency_id: :eth, address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84')
-        WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).raises(Peatio::Wallet::ClientError.new('something went wrong'))
-      end
-
-      it 'returns error' do
-        api_post '/api/v2/public/webhooks/deposit', params: request_body
-        expect(response.status).to eq 422
-        expect(response).to include_api_error('public.webhook.cannot_perfom_transfer')
-      end
-    end
-
-    context 'address confirmation event' do
-      let(:request_body) {
-        { 'event' => 'deposit',
-          'address' => '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-          'type' => 'address_confirmation',
-          'walletId' => '5e4e824894d4902c060f20c28b161fa8',
-          'hash' => '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
-        }
-      }
-
-      context 'valid webhook callback' do
-        context 'update payment address' do
           before do
-            member.get_account(:eth).payment_addresses.create(currency_id: :eth, address: nil, details: { address_id: 'address_id' })
-            WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).returns({ address_id: 'address_id', currency_id: 'eth' })
+            WalletService.any_instance.stubs(:trigger_webhook_event).returns([])
           end
 
-          it 'should create address for member' do
-            api_post '/api/v2/public/webhooks/deposit', params: request_body
-            expect(response.status).to eq 200
-            expect(member.get_account(:eth).payment_addresses[0].address).to eq request_body['address']
+          it do
+            expect {
+              api_post '/api/v2/public/webhooks/opendax_cloud/deposit'
+            }.not_to change { Deposit.count }
           end
         end
 
-        context 'skip payment address' do
-          before do
-            member.get_account(:eth).payment_addresses.create(currency_id: :eth, address: request_body['address'], details: { address_id: 'address_id' })
-            WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).returns({ address_id: 'address_id', currency_id: 'eth' })
+        context 'there is no JWT' do
+          let(:params) do
+            {
+              adapter: 'opendax_cloud',
+              event: 'deposit'
+            }
           end
 
-          it 'should not update address if address already exists' do
-            api_post '/api/v2/public/webhooks/deposit', params: request_body
-            expect(response.status).to eq 200
-            expect(member.get_account(:eth).payment_addresses[0].created_at).to eq member.get_account(:eth).payment_addresses[0].updated_at
+          it do
+            api_post '/api/v2/public/webhooks/opendax_cloud/deposit'
+
+            expect(response.status).to eq 422
+            expect(response).to include_api_error('public.webhook.cannot_perfom_opendax_cloud_deposit')
+          end
+        end
+
+        context 'transactions exist' do
+          let(:transaction) do
+            Peatio::Transaction.new(
+              currency_id: :eth,
+              hash: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
+              amount: 0.5,
+              to_address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84',
+              block_number: 16880960,
+              txout: 0,
+              status: :success
+            )
+          end
+
+          context 'accepted deposits exist' do
+            let(:params) do
+              {
+                adapter: 'opendax_cloud',
+                event: 'deposit'
+              }
+            end
+
+            before do
+              WalletService.any_instance.stubs(:trigger_webhook_event).returns([transaction])
+            end
+
+            context 'there is no payment address' do
+              it do
+                expect {
+                  api_post '/api/v2/public/webhooks/opendax_cloud/deposit'
+                }.not_to change { Deposit.count }
+              end
+            end
+
+            context 'there is payment address' do
+              before do
+                # disable first deposit wallet for eth to have ability to use opendax cloud deposit wallet
+                Wallet.deposit_wallet(transaction.currency_id).update(status: 'disabled')
+                PaymentAddress.create(member: member, wallet: deposit_wallet, address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84')
+              end
+
+              it do
+                expect {
+                  api_post '/api/v2/public/webhooks/opendax_cloud/deposit'
+                }.to change { Deposit.count }.by(1)
+              end
+            end
           end
         end
       end
+    end
 
-      context 'adapter raises error invalid' do
-        before do
-          member.get_account(:eth).payment_addresses.create(currency_id: :eth, address: nil, details: { address_id: 'address_id' })
-          WalletService.any_instance.stubs(:trigger_webhook_event).with(request_body).raises(Peatio::Wallet::ClientError.new('something went wrong'))
+    context 'withdraw' do
+      context 'hot wallet doesnt exist' do
+        let(:params) do
+          {
+            adapter: 'opendax_cloud',
+            event: 'withdraw'
+          }
         end
 
-        it 'returns error' do
-          api_post '/api/v2/public/webhooks/deposit', params: request_body
-          expect(response.status).to eq 422
-          expect(response).to include_api_error('public.webhook.cannot_perfom_address_confirmation')
+        it do
+          expect {
+            api_post '/api/v2/public/webhooks/opendax_cloud/withdraw'
+          }.not_to change { Withdraw.count }
+
+          expect(Wallet.where(status: :active, kind: :hot, gateway: params[:adapter]).count).to eq 0
+        end
+      end
+
+      context 'hot wallet exist' do
+        let!(:hot_wallet) { create(:wallet, :eth_opendax_cloud_hot) }
+
+        context 'transactions doesnt exist' do
+          let(:params) do
+            {
+              adapter: 'opendax_cloud',
+              event: 'withdraw'
+            }
+          end
+
+          before do
+            WalletService.any_instance.stubs(:trigger_webhook_event).returns([])
+          end
+
+          it do
+            api_post '/api/v2/public/webhooks/opendax_cloud/withdraw'
+            expect(response.status).to eq 200
+          end
+        end
+
+        context 'transactions exist' do
+          context 'without options' do
+            let(:transaction) do
+              Peatio::Transaction.new(
+                currency_id: :eth,
+                hash: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
+                amount: 0.5,
+                to_address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84',
+                block_number: 16880960,
+                txout: 0,
+                status: :success
+              )
+            end
+
+            let(:params) do
+              {
+                adapter: 'opendax_cloud',
+                event: 'withdraw'
+              }
+            end
+
+
+            before do
+              member.touch_accounts
+              member.accounts.map { |a| a.update(balance: 500) }
+              WalletService.any_instance.stubs(:trigger_webhook_event).returns([transaction])
+            end
+
+            let!(:withdraw) { create(:eth_withdraw, :with_beneficiary, aasm_state: :prepared, member: member, txid: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac')}
+
+            before do
+              withdraw.accept!
+              withdraw.process!
+              withdraw.dispatch!
+            end
+
+            it do
+              api_post '/api/v2/public/webhooks/opendax_cloud/withdraw'
+              expect(response.status).to eq 200
+
+              withdraw.reload
+              expect(withdraw.aasm_state).to eq 'succeed'
+            end
+
+            context 'failed transaction' do
+              let(:transaction) do
+                Peatio::Transaction.new(
+                  currency_id: :eth,
+                  hash: '0xa049b0202ba078caa723c6b59594247b0c9f33e24878950f8537cedff9ea20ac',
+                  amount: 0.5,
+                  to_address: '0x1ef338196bd0207ba4852ba7a6847eed59331b84',
+                  block_number: 16880960,
+                  txout: 0,
+                  status: :failed
+                )
+              end
+
+              it do
+                api_post '/api/v2/public/webhooks/opendax_cloud/withdraw'
+                expect(response.status).to eq 200
+
+                withdraw.reload
+                expect(withdraw.aasm_state).to eq 'failed'
+              end
+            end
+          end
         end
       end
     end

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -19,6 +19,21 @@ FactoryBot.define do
       secret             { 'changeme' }
     end
 
+    trait :eth_opendax_cloud_deposit do
+      after(:create) do |w|
+        CurrencyWallet.create(currency_id: 'eth', wallet_id: w.id)
+      end
+      blockchain_key     { 'eth-rinkeby' }
+      name               { 'Ethereum Deposit Opendax Cloud Wallet' }
+      address            { '0x828058628DF254Ebf252e0b1b5393D1DED91E369' }
+      kind               { 'deposit' }
+      max_balance        { 0.0 }
+      status             { 'active' }
+      gateway            { 'opendax_cloud' }
+      uri                { 'http://127.0.0.1:8545' }
+      secret             { 'changeme' }
+    end
+
     trait :eth_hot do
       after(:create) do |w|
         CurrencyWallet.create(currency_id: 'eth', wallet_id: w.id)
@@ -30,6 +45,21 @@ FactoryBot.define do
       max_balance        { 100.0 }
       status             { 'active' }
       gateway            { 'geth' }
+      uri                { 'http://127.0.0.1:8545' }
+      secret             { 'changeme' }
+    end
+
+    trait :eth_opendax_cloud_hot do
+      after(:create) do |w|
+        CurrencyWallet.create(currency_id: 'eth', wallet_id: w.id)
+      end
+      blockchain_key     { 'eth-rinkeby' }
+      name               { 'Ethereum Hot Opendax Cloud Wallet' }
+      address            { '0xb6a61c43DAe37c0890936D720DC42b5CBda990F9' }
+      kind               { 'hot' }
+      max_balance        { 100.0 }
+      status             { 'active' }
+      gateway            { 'opendax_cloud' }
       uri                { 'http://127.0.0.1:8545' }
       secret             { 'changeme' }
     end

--- a/spec/factories/withdraw.rb
+++ b/spec/factories/withdraw.rb
@@ -38,6 +38,24 @@ FactoryBot.define do
     type { 'Withdraws::Coin' }
   end
 
+  factory :eth_withdraw, class: Withdraws::Coin do
+    currency { Currency.find(:eth) }
+    member { create(:member, :level_3) }
+    rid { Faker::Blockchain::Bitcoin.address }
+    sum { 10.to_d }
+    type { 'Withdraws::Coin' }
+
+    trait :with_beneficiary do
+      beneficiary do
+        create(:beneficiary,
+               currency: currency,
+               member: member,
+               state: :active)
+      end
+      rid { nil }
+    end
+  end
+
   factory :usd_withdraw, class: Withdraws::Fiat do
 
     # We need to have valid Liability-based balance to spend funds.

--- a/spec/lib/opendax_cloud/wallet_spec.rb
+++ b/spec/lib/opendax_cloud/wallet_spec.rb
@@ -185,43 +185,77 @@ describe OpendaxCloud::Wallet do
   end
 
   context :trigger_webhook_event do
-    let(:rsa_private) { OpenSSL::PKey::RSA.generate 2048 }
+    let(:rsa_private) { OpenSSL::PKey::EC.generate('prime256v1') }
 
     let(:payload) {
       {
         currency: 'eth',
-        amount: '2323',
+        amount: '1000000000000000000',
         blockchain_txid: 'c37ae1677c4c989dbde9ac22be1f3ff3ac67ed24732a9fa8c9258fdff0232d72',
         state: 'succeed',
         tid: '0x6d6cabaa7232d7f45b143b445114f7e92350a2aa'
       }
     }
 
-    let(:jwt_token) { JWT.encode(payload, rsa_private, 'RS256') }
+    let(:eth) do
+      Currency.find_by(id: :eth)
+    end
+
+    let(:uri) { 'http://127.0.0.1:8000' }
+
+    let(:settings) do
+      {
+        wallet:
+          { address:     'something',
+            uri:         uri
+          },
+        currency: eth.to_blockchain_api_settings
+      }
+    end
+
+    before do
+      wallet.configure(settings)
+    end
+
+    let(:jwt_token) { JWT.encode(payload, rsa_private, 'ES256') }
 
     context 'successful response' do
       before do
-        ENV['OPENFINEX_CLOUD_PUBLIC_KEY'] = Base64.urlsafe_encode64(rsa_private.public_key.to_pem)
+        ENV['OPENFINEX_CLOUD_PUBLIC_KEY'] = Base64.urlsafe_encode64(OpenSSL::PKey::EC.new(rsa_private).to_pem)
       end
 
-      it 'returns transactions' do
-        res = wallet.trigger_webhook_event(OpenStruct.new('body': StringIO.new(jwt_token)))
+      context 'deposit' do
+        it 'returns transactions' do
+          res = wallet.trigger_webhook_event(OpenStruct.new({'body': StringIO.new(jwt_token), 'params': {'event': 'deposit'}}))
 
-        expect(res[0].amount).to eq payload[:amount]
-        expect(res[0].currency_id).to eq payload[:currency]
-        expect(res[0].hash).to eq payload[:blockchain_txid]
-        expect(res[0].status).to eq payload[:state]
-        expect(res[0].options[:tid]).to eq payload[:tid]
+          expect(res[0].amount).to eq 1.0
+          expect(res[0].currency_id).to eq payload[:currency]
+          expect(res[0].hash).to eq payload[:blockchain_txid]
+          expect(res[0].status).to eq payload[:state]
+          expect(res[0].options[:tid]).to eq payload[:tid]
+        end
+      end
+
+      context 'withdraw' do
+        it 'returns transactions' do
+          res = wallet.trigger_webhook_event(OpenStruct.new({'body': StringIO.new(jwt_token), 'params': {'event': 'withdraw'}}))
+
+          expect(res[0].amount).to eq payload[:amount].to_d
+          expect(res[0].currency_id).to eq payload[:currency]
+          expect(res[0].hash).to eq payload[:blockchain_txid]
+          expect(res[0].status).to eq payload[:state]
+          expect(res[0].options[:tid]).to eq payload[:tid]
+        end
       end
     end
 
     context 'successful response' do
       before do
-        ENV['OPENFINEX_CLOUD_PUBLIC_KEY'] = Base64.urlsafe_encode64(OpenSSL::PKey::RSA.generate(2048).to_pem)
+        ENV['OPENFINEX_CLOUD_PUBLIC_KEY'] = Base64.urlsafe_encode64(OpenSSL::PKey::EC.generate('prime256v1').to_pem)
       end
 
       it 'returns error' do
-        expect { wallet.trigger_webhook_event(OpenStruct.new('body': StringIO.new(jwt_token))) }.to raise_error(JWT::VerificationError)
+        expect { wallet.trigger_webhook_event(OpenStruct.new({'body': StringIO.new(jwt_token), 'params': {'event': 'deposit'} })) }.to raise_error(JWT::VerificationError)
       end
     end
   end

--- a/spec/lib/opendax_cloud/wallet_spec.rb
+++ b/spec/lib/opendax_cloud/wallet_spec.rb
@@ -231,7 +231,7 @@ describe OpendaxCloud::Wallet do
           expect(res[0].amount).to eq 1.0
           expect(res[0].currency_id).to eq payload[:currency]
           expect(res[0].hash).to eq payload[:blockchain_txid]
-          expect(res[0].status).to eq payload[:state]
+          expect(res[0].status).to eq 'pending'
           expect(res[0].options[:tid]).to eq payload[:tid]
         end
       end
@@ -243,7 +243,7 @@ describe OpendaxCloud::Wallet do
           expect(res[0].amount).to eq payload[:amount].to_d
           expect(res[0].currency_id).to eq payload[:currency]
           expect(res[0].hash).to eq payload[:blockchain_txid]
-          expect(res[0].status).to eq payload[:state]
+          expect(res[0].status).to eq 'success'
           expect(res[0].options[:tid]).to eq payload[:tid]
         end
       end

--- a/spec/lib/opendax_cloud/wallet_spec.rb
+++ b/spec/lib/opendax_cloud/wallet_spec.rb
@@ -112,9 +112,9 @@ describe OpendaxCloud::Wallet do
 
       let(:request_params) do
         {
-          currency_id:    'eth',
-          to:           transaction.to_address,
-          amount:       transaction.amount.to_d,
+          currency_id: 'eth',
+          to_address:  transaction.to_address,
+          amount:      transaction.amount.to_d,
         }
       end
 
@@ -228,7 +228,7 @@ describe OpendaxCloud::Wallet do
         it 'returns transactions' do
           res = wallet.trigger_webhook_event(OpenStruct.new({'body': StringIO.new(jwt_token), 'params': {'event': 'deposit'}}))
 
-          expect(res[0].amount).to eq 1.0
+          expect(res[0].amount).to eq payload[:amount].to_d
           expect(res[0].currency_id).to eq payload[:currency]
           expect(res[0].hash).to eq payload[:blockchain_txid]
           expect(res[0].status).to eq 'pending'

--- a/spec/services/wallet_service_spec.rb
+++ b/spec/services/wallet_service_spec.rb
@@ -683,6 +683,7 @@ describe WalletService do
       subject { service.collect_deposit!(deposit, spread_deposit) }
 
       before do
+        deposit.member.payment_address(service.wallet.id).update(address: deposit.address)
         service.adapter.expects(:create_transaction!).returns(transaction.first)
       end
 
@@ -717,6 +718,7 @@ describe WalletService do
       subject { service.collect_deposit!(deposit, spread_deposit) }
 
       before do
+        deposit.member.payment_address(service.wallet.id).update(address: deposit.address)
         service.adapter.expects(:create_transaction!).with(spread_deposit.first, subtract_fee: true).returns(transaction.first)
         service.adapter.expects(:create_transaction!).with(spread_deposit.second, subtract_fee: true).returns(transaction.second)
       end


### PR DESCRIPTION
- [x] Define payload that we should send from openfinex-cloud
- [x] Update opendax-cloud plugin with the ability to check signature (bearer token, ENV for openfinex public key should be added)
- [x] Update opendax-cloud plugin with the ability to parse event from openfinex-cloud and transform it to Peatio::Transaction.
- [x] Update peatio-bitgo plugin to parse and process payload inside plugin
- [x] Define state translations for deposit/withdraw to transaction
- [x] Coin ID is not found in trigger webhook
- [x] Add documentation