### PR TITLE
Feature/customize registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tmp
 /config/secrets
 /config/seed
 /config/bench/*.yml
+/config/registries.local.yml
 
 # Ignore translations.js
 /public/javascripts/translations.js

--- a/config/initializers/blockchain_api.rb
+++ b/config/initializers/blockchain_api.rb
@@ -1,3 +1,0 @@
-Peatio::Blockchain.registry[:bitcoin] = Bitcoin::Blockchain
-Peatio::Blockchain.registry[:geth] = Ethereum::Blockchain
-Peatio::Blockchain.registry[:parity] = Ethereum::Blockchain

--- a/config/initializers/registries.rb
+++ b/config/initializers/registries.rb
@@ -1,20 +1,16 @@
-# Wallets
+registries = {
+  wallets: Peatio::Wallet.registry,
+  blockchains: Peatio::Blockchain.registry,
+  upstreams: Peatio::Upstream.registry
+}
 
-Peatio::Wallet.registry[:bitcoind] = Bitcoin::Wallet
-Peatio::Wallet.registry[:geth] = Ethereum::Wallet
-Peatio::Wallet.registry[:parity] = Ethereum::Wallet
-Peatio::Wallet.registry[:gnosis] = Gnosis::Wallet
-Peatio::Wallet.registry[:ow_hdwallet] = OWHDWallet::Wallet
-Peatio::Wallet.registry[:opendax] = OWHDWallet::Wallet
-Peatio::Wallet.registry[:opendax_cloud] = OpendaxCloud::Wallet
-
-# Blockchains
-
-Peatio::Blockchain.registry[:bitcoin] = Bitcoin::Blockchain
-Peatio::Blockchain.registry[:geth] = Ethereum::Blockchain
-Peatio::Blockchain.registry[:parity] = Ethereum::Blockchain
-
-
-# Upstreams
-require 'peatio/upstream/opendax'
-Peatio::Upstream.registry[:opendax] = Peatio::Upstream::Opendax
+%w(config/registries.local.yml config/registries.yml).each do |config_file|
+  next unless File.exists? config_file
+  YAML.load_file(config_file).each_pair do |registry_name, items|
+    registry = registries[registry_name.to_sym] || raise("Unknown registry (#{registry_name}) defined in #{config_file}")
+    items.each do |item_name, item_class|
+      registry[item_name.to_sym] = item_name.classify
+    end
+  end
+  break
+end

--- a/config/initializers/registries.rb
+++ b/config/initializers/registries.rb
@@ -1,3 +1,5 @@
+# Wallets
+
 Peatio::Wallet.registry[:bitcoind] = Bitcoin::Wallet
 Peatio::Wallet.registry[:geth] = Ethereum::Wallet
 Peatio::Wallet.registry[:parity] = Ethereum::Wallet
@@ -5,3 +7,14 @@ Peatio::Wallet.registry[:gnosis] = Gnosis::Wallet
 Peatio::Wallet.registry[:ow_hdwallet] = OWHDWallet::Wallet
 Peatio::Wallet.registry[:opendax] = OWHDWallet::Wallet
 Peatio::Wallet.registry[:opendax_cloud] = OpendaxCloud::Wallet
+
+# Blockchains
+
+Peatio::Blockchain.registry[:bitcoin] = Bitcoin::Blockchain
+Peatio::Blockchain.registry[:geth] = Ethereum::Blockchain
+Peatio::Blockchain.registry[:parity] = Ethereum::Blockchain
+
+
+# Upstreams
+require 'peatio/upstream/opendax'
+Peatio::Upstream.registry[:opendax] = Peatio::Upstream::Opendax

--- a/config/initializers/upstreams.rb
+++ b/config/initializers/upstreams.rb
@@ -1,3 +1,0 @@
-require 'peatio/upstream/opendax'
-
-Peatio::Upstream.registry[:opendax] = Peatio::Upstream::Opendax

--- a/config/registries.yml
+++ b/config/registries.yml
@@ -1,0 +1,16 @@
+wallets:
+  bitcoind: Bitcoin::Wallet
+  geth: Ethereum::Wallet
+  parity: Ethereum::Wallet
+  gnosis: Gnosis::Wallet
+  opendax: OWHDWallet::Wallet
+  ow_hdwallet: OWHDWallet::Wallet
+  opendax_cloud: OpendaxCloud::Wallet
+
+blockchains:
+  bitcoin: Bitcoin::Blockchain
+  geth: Ethereum::Blockchain
+  parity: Ethereum::Blockchain
+
+upstreams:
+  opendax: Peatio::Upstream::Opendax


### PR DESCRIPTION
There reasons is to have flex way to add or remove wallets, blockchains and upstreams with no code changes.
It must not break current deploy and installation process and be compatible with opendax