### PR TITLE
Fix: add 'state' to create engine params

### DIFF
--- a/app/api/v2/admin/engines.rb
+++ b/app/api/v2/admin/engines.rb
@@ -49,6 +49,10 @@ module API
                    desc: -> { 'Credentials for remote engine' }
           optional :secret,
                    desc: -> { 'Credentials for remote engine' }
+          optional :state,
+                   values: { value: ::Engine::STATES.values, message: 'admin.engine.invalid_state' },
+                   default: Engine::STATES[:online],
+                   desc: -> { API::V2::Admin::Entities::Engine.documentation[:state][:desc] }
           optional :data,
                    desc: -> { 'Metadata for engine' }
         end

--- a/spec/api/v2/admin/engines_spec.rb
+++ b/spec/api/v2/admin/engines_spec.rb
@@ -84,6 +84,7 @@ describe API::V2::Admin::Engines, type: :request do
         uid: 'UID123456',
         key: 'your_key',
         secret: 'your_secret',
+        state: Engine::STATES.values[0],
         data: { some_data: 'some data' }
       }
     end
@@ -94,6 +95,7 @@ describe API::V2::Admin::Engines, type: :request do
       expect(response).to be_successful
       expect(result['name']).to eq 'new-engine'
       expect(result['data'].blank?).to eq true
+      expect(result['state']).to eq 'online'
 
       api_post '/api/v2/admin/engines/new', token: token, params: valid_params
       expect(response).to have_http_status 422


### PR DESCRIPTION
Prevent engines from creating as 'online' even when 'offline' state provided during creation.