### PR TITLE
fix PNL exclude user roles

### DIFF
--- a/app/jobs/cron/stats_member_pnl.rb
+++ b/app/jobs/cron/stats_member_pnl.rb
@@ -10,7 +10,7 @@ module Jobs::Cron
         if exclude_user_ids.empty?
           filter_trades = ''
         else
-          filter_trades = "AND (trades.taker_id != trades.maker_id OR trades.taker_id NOT IN (#{exclude_user_ids.join(',')}))"
+          filter_trades = "AND trades.maker_id NOT IN (#{exclude_user_ids.join(',')}) AND trades.taker_id NOT IN (#{exclude_user_ids.join(',')})"
         end
 
         query = "


### PR DESCRIPTION
current query is if `maker_id != taker_id OR taker_id not in (..)`
which just does not work as you can guess.

also if ur even reading this, bring back 3.0 lol?