### PR TITLE
skip aml_processing for errored deposits

### DIFF
--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -70,7 +70,7 @@ class Deposit < ApplicationRecord
     end
 
     event :process do
-      transitions from: %i[aml_processing aml_suspicious accepted errored], to: :aml_processing do
+      transitions from: %i[aml_processing aml_suspicious accepted], to: :aml_processing do
         guard do
           Peatio::AML.adapter.present? || Peatio::App.config.manual_deposit_approval
         end


### PR DESCRIPTION
re-processing an errored deposit when AML is enabled attempts to unlock already unlocked funds, causing it to be stuck.
errored state is only possible after successful aml_check, and funds are unlocked